### PR TITLE
DIE-50: add repo agent configuration and workflow

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -1,0 +1,416 @@
+# Die Robot — Claude Workflow
+
+The sequence every change follows. Conventions live in `.claude/rules/` — this file is *the
+order things happen*, not the conventions themselves.
+
+Three parts:
+
+1. **Setup** — once, at the start of a task
+2. **The change loop** — repeats once per logical change, ending in a commit
+3. **Close-out** — once, when the branch is ready to become a PR
+
+A step marked **[BLOCKING]** means work stops on failure. Do not proceed until resolved.
+
+---
+
+## The three lanes
+
+A game repo does not contain one kind of change. This workflow recognises three, and the
+lane a change is in determines which steps it takes.
+
+| Lane | What it is | How you know |
+|---|---|---|
+| **Code** | C++ under `Source/`, build files, `Config/*.ini` | The default. Takes every step. |
+| **Content** | Blueprints, maps, DataAssets, art, audio under `Content/` | Binary `.uasset`. `git diff` shows nothing. See `rules/content-changes.md`. |
+| **EXP** | A design experiment being tried, not shipped | Branch `exp/*`. Exempt from tests and review. **Never exempt from process.** |
+
+Most real branches are **mixed** — a C++ change plus the Blueprint that calls it. A mixed
+change takes the union of both lanes' requirements, never the cheaper one.
+
+---
+
+## A note on the two code reviews
+
+They are **different mechanisms** and the distinction is load-bearing:
+
+| Review | Mechanism | Who runs it |
+|---|---|---|
+| Per-change review, full-PR review | The **`code-review` skill**, invoked via the Skill tool | Claude |
+| Ultra review | The **`/code-review ultra` slash command** | **User only** |
+
+`/code-review ultra` is user-triggered and billed. **Claude cannot launch it** — not via
+Bash, not via the Skill tool. Any step calling for ultra is necessarily a stop-and-hand-off.
+
+---
+
+## Documentation-only changes
+
+Some changes contain no behavior — a rules edit, a checklist update. Running `test-writer`
+on prose produces nothing, and a performance review of a markdown diff is theatre.
+
+**A change qualifies as documentation-only when every file it touches is markdown or plain
+prose, and none of them alters behavior.**
+
+| File | Qualifies? |
+|---|---|
+| `*.md` anywhere | Yes |
+| Anything under `Source/` | **No** |
+| Anything under `Content/` | **No — content lane** |
+| `Config/*.ini`, `*.uproject`, `*.Build.cs`, `*.Target.cs` | **No — these are behavior** |
+| `.github/workflows/*`, `.gitattributes`, `.gitignore` | **No — behavioral** |
+
+A qualifying change may skip **L.2** (tests), **L.3** (performance), **L.4** (code review),
+**C.1**, **C.2** (smoke) and **C.4**. It still takes S.1–S.3, L.1, L.5, C.3, C.5 and C.6 —
+the task still needs an issue, a branch, a commit, a check against what was asked for, a
+vault answer, and a PR that meets the standard.
+
+**State the exemption in the commit body when you use it.** An exemption taken without
+writing it down is how a rule quietly stops meaning anything.
+
+The exemption is for **prose, not for small diffs**. When a change is mostly prose but
+touches one behavioral file, the honest options are to run the steps, or to split the
+behavioral file into its own commit that takes them.
+
+---
+
+# Setup
+
+## S.1 — Confirm rules are loaded
+
+This session must have read every file in `.claude/rules/` at least once:
+
+- `architecture.md`
+- `unreal-style.md`
+- `content-changes.md`
+- `git-workflow.md`
+- `linear-issues.md`
+
+If already read in this session, skip.
+
+## S.2 — Read the relevant vault docs
+
+The vault at `~/Documents/RLOV/DieRobot/` is the source of truth for *how Die Robot is
+supposed to work*. It is not in git and will not appear in any repo search — you must read
+it deliberately.
+
+**Always, every session:** `02 Technical/Current State.md`. It carries the engine paths, the
+toolchain traps, the open bug list, and the gotchas that have already cost hours. Skipping
+it is how the same hour gets burned twice.
+
+Then, by area:
+
+| If the task touches... | Read in vault... |
+|---|---|
+| Any system's real state, or a bug | Systems Inventory |
+| Enemy behavior, wave pacing, player verbs, difficulty | Pillars & Decisions |
+| Something the design hasn't settled | Open Questions & Graveyard |
+| Why a past technical choice was made | Decision Log |
+| Build, CI, test infrastructure | Setup Brief |
+| A term you don't recognize | Glossary |
+
+The plan you propose must be consistent with what the vault describes. **Where it conflicts,
+say so out loud rather than silently picking one** — a design decision the code violates is
+a finding, not an inconvenience. `ScaleHealth()` inflating enemy health against decision D4
+is the standing example.
+
+If the vault doesn't cover the area you're touching, flag it as a gap — close-out step C.4
+may add a page.
+
+## S.3 — Linear & branch
+
+- Confirm an issue exists in team **DIE** under the **Die Robot** initiative, in the right
+  project. Create one if not, following `rules/linear-issues.md`.
+- Link the issue to the project and set it to **In Progress** in a single `save_issue` call.
+- Create a `die-XX` branch off `main` per `rules/git-workflow.md`.
+
+**[BLOCKING]** If the current branch is a Claude worktree branch (`claude/*`) rather than
+`die-XX`, stop and say so. Linear cannot link a `claude/*` branch.
+
+**[BLOCKING] Confirm the branch point is current.** Run `git log --oneline -1 origin/main`
+and confirm the branch is based on it. A worktree created earlier in the session may sit on
+a stale commit — this repo has already had a branch silently eight months behind `main`, and
+with 8.8 GB of binary content that is not a preference, it is a trap.
+
+---
+
+# The Change Loop
+
+**Repeats once per logical change.** A PR is N passes through this loop, producing N
+commits. Each commit that lands has already been reviewed.
+
+## L.1 — Implement
+
+Write the code. Follow:
+
+- `rules/architecture.md` for module layout and layer order
+- `rules/unreal-style.md` for UE idioms, naming, and ownership
+- `rules/content-changes.md` if the change touches `Content/`
+
+**Gate — the editor must be closed, then the editor target compiles:**
+
+```powershell
+& "D:\UnrealEngine\UE_5.8\Engine\Build\BatchFiles\Build.bat" DieRobotEditor Win64 Development -Project="C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -WaitMutex
+```
+
+**Second gate, whenever a change alters a `UPROPERTY`, `UFUNCTION`, class name, or any
+reflected signature:** Blueprints referencing it may now be silently broken, because C++
+compiling proves nothing about the BP layer.
+
+```powershell
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -run=CompileAllBlueprints -unattended -nopause
+```
+
+This is the game-dev step Harbor has no analogue for. A pure-C++ refactor that compiles
+clean can still break thirty Blueprints, and nothing in the C++ toolchain will tell you.
+
+## L.2 — Tests
+
+Invoke the **`test-writer`** agent on the code that just landed.
+
+**Gate:** the `DieRobot.Settled.*` suite passes.
+
+> **Currently aspirational.** The suite does not exist yet — Setup Brief Phase 2.3 lands it.
+> `Private/Tests/TestObj.cpp` is **not** a test; it is a shipped interactable lever that
+> early-starts a wave. Do not mistake it for coverage.
+>
+> **Until the suite exists**, this step still runs — `test-writer` writes the first tests
+> for the system being touched, and they become the seed of the suite. The gate is: the
+> tests you just wrote pass. A change to a system with no tests is the opportunity to give
+> it some, not a reason to skip.
+
+**Exemption:** documentation-only changes and the EXP lane skip this step.
+
+**Content-lane note:** a Blueprint or DataAsset change is usually not unit-testable. Its
+verification is the smoke pass at L.3 plus the evidence required by
+`rules/content-changes.md` — not a skipped step.
+
+## L.3 — Performance review [BLOCKING]
+
+Invoke the **`performance-reviewer`** agent.
+
+**Why this and not a security audit:** Die Robot is a single-player offline game. There is
+no auth, no PII, no server, no untrusted input. The hazard is not a breach — it is a frame
+time regression that makes wave 12 unplayable, and those are invisible in a diff.
+
+**Scope — this step is conditional:**
+
+- **Runs** when the change touches anything on a per-frame or per-enemy path: `Tick`,
+  behavior tree tasks and services, `AI/`, `Components/Combat/`, `Components/Navigation/`,
+  `Components/StatusEffect/`, `Subsystems/Wave/`, `Subsystems/SynergySystem/`, spawn or
+  destroy paths, or anything on the ultra risk bar (see C.4).
+- **Skipped otherwise, with an explicit one-line note saying so.** A UI text change does not
+  need a performance review — but the skip is stated, never silent.
+- **Runs at least once before close-out** on any branch containing code. If every loop pass
+  skipped it, run it at C.1.
+
+**Gate:** PASS, or every finding addressed.
+
+- A **BLOCK** finding halts the loop. Return to L.1, fix, re-run from L.2.
+- An **EXPAND** finding is not a blocker but a strategic signal — a cost is growing in a way
+  the current scope doesn't cover. Document it, decide whether to expand scope now or in a
+  follow-up, and carry it into C.4.
+
+## L.4 — Code review
+
+Invoke the **`code-review` skill** on the **uncommitted** diff.
+
+Reviewing before the commit is deliberate: the commit that lands is then the reviewed
+artifact. Reviewing after would make the reviewed object and the landed object different
+things.
+
+**Gate:** every finding fixed, or explicitly accepted in-code with a comment giving the
+reasoning. An accepted finding with no written reason is not accepted — it's forgotten.
+
+**Content-lane substitution.** The `code-review` skill cannot read a `.uasset`. For a
+content-only change, the substitute is the evidence package in `rules/content-changes.md`:
+a written statement of what changed and why, plus a screenshot or clip. **This is a
+substitution, not an exemption** — the change is still reviewed, by a human, against a
+description that a human wrote.
+
+**Exemption:** documentation-only changes and the EXP lane skip this step.
+
+## L.5 — Commit
+
+Commit per `rules/git-workflow.md` — `DIE-XX:` subject under 72 characters, `## What
+changed` and `## Why` both required.
+
+Then either return to L.1 for the next logical change, or proceed to close-out.
+
+---
+
+# Close-Out
+
+**Runs once**, when every logical change is committed and the branch is ready to become a
+PR.
+
+## C.1 — Deferred performance review
+
+If every pass through L.3 was skipped, run **`performance-reviewer`** now over the whole
+branch.
+
+Skip only when the agent already ran at least once during the loop, **or** the branch is
+documentation-only.
+
+## C.2 — Smoke pass [BLOCKING]
+
+Run the manual pass in `docs/smoke-checklist.md`.
+
+**This is the step that has no Harbor equivalent and the one most worth defending.** Three
+of the bugs found during the 5.8 recovery were invisible to code review and only findable by
+running the thing. DIE-24 in particular survived eight sessions and would have been caught
+by a single save/load round-trip.
+
+**Minimum bar:** one full wave, start to finish, from the main menu — not from PIE dropped
+into the level. Transition, build, combat, wave completion, save, reload, verify the base
+came back the same size.
+
+The full checklist is required when the branch touches save/load, the build system,
+navigation, or wave logic. For a narrow change, run the sections the change can plausibly
+reach and **state which sections you ran and which you didn't.**
+
+**Record the result in the PR's `## Test plan`.** "Smoke passed" is not a result. Which
+wave, what was built, what the save round-trip showed.
+
+## C.3 — Task review
+
+Invoke the **`linear-task-reviewer`** agent against the Linear issue and the full branch
+diff.
+
+**Gate:** every Success Criterion met. Drift resolved in both directions — by updating the
+issue, filing a new one, or removing the work. Never left unnoted.
+
+## C.4 — Full-PR code review
+
+Invoke the **`code-review` skill** over `merge-base..HEAD`.
+
+The per-change reviews covered each commit in isolation; this pass looks for what only
+appears across commits — a guard added in commit 2 that commit 5 routes around, a helper
+introduced twice, a signature that drifted between its definition and its callers.
+
+**Exemption:** documentation-only branches skip this step. The risk bar below still applies
+to any branch containing code or content.
+
+### The ultra risk bar
+
+Ultra is required when the PR touches any of:
+
+- **Save/load** — `Subsystems/SaveLoad/`, `USaveLoadStruct`, `FBuildableData`, or any struct
+  serialized into a save. *A bad write is discovered by a player, weeks later, as a lost
+  base — and there is no schema version to migrate from.*
+- **The build system** — `BuildSystemManagerComponent`, `ABuildableBase`, placement,
+  snapping, or attachment GUIDs. *This is the core verb of the game and it persists.*
+- **Navigation** — `AI/`, corridor pathing, `NavigationHelperComponent`, navmesh config, or
+  `RecastNavMesh` actor properties. *Already the known-weakest system, and the failure mode
+  is enemies walking through walls or standing still.*
+- **Damage and attributes** — `CombatComponent`, `TakeDamage` overrides, `ScaleHealth`,
+  weapon damage math, status effect application. *Every balance decision the design makes
+  rests on these being right, and three of them are currently wrong.*
+- **The GAS migration** — any commit in that project, without exception. *It replaces four
+  of the above at once.*
+- **Build configuration** — `*.Build.cs`, `*.Target.cs`, `DieRobot.uproject`, or the
+  `[CoreRedirects]` block in `DefaultEngine.ini`. *These are how the 5.8 upgrade nearly
+  failed, and a wrong redirect breaks saves silently.*
+
+**On a hit: stop. Name which trigger fired. Hand off to the user**, who runs
+`/code-review ultra` and brings back the findings. Claude cannot run this step.
+
+## C.5 — Vault update check
+
+Ask: **did anything we built or decided warrant a vault change?**
+
+| If we did this... | Suggest updating... |
+|---|---|
+| Made a significant technical or process decision | Decision Log |
+| Settled a design question, or killed one | Pillars & Decisions, Open Questions & Graveyard |
+| Changed what a system does, or fixed a listed bug | Systems Inventory |
+| Changed engine version, build commands, or toolchain | Current State |
+| Introduced a new term, or retired one | Glossary |
+| Landed a test that armors a system | Systems Inventory (the SETTLED claim), Current State |
+| Found a gotcha that cost more than an hour | Current State → Gotchas |
+| `performance-reviewer` returned an EXPAND finding | Decision Log + Systems Inventory |
+
+When a trigger fires: state what should change and why, propose specific page edits, offer
+to make them.
+
+If nothing warranted a vault change, **say so explicitly. Silence is not an answer.**
+
+**The vault drifting from reality is worse than no vault.** This step exists to catch drift
+while context is fresh — and because the vault is outside git, nothing else will ever catch
+it.
+
+## C.6 — PR
+
+Per `rules/git-workflow.md`:
+
+1. Pre-push checks — see `rules/git-workflow.md` → Pre-Push Checks.
+2. Push the branch. Then confirm it actually landed:
+   `git log --branches --not --remotes --oneline` must be empty. **A push to this repo can
+   fail on an LFS timeout and still print a plausible-looking tail** — that has happened.
+3. Open a PR meeting the **PR Description Standard** in `rules/git-workflow.md` — not just
+   the headings, the prose standard under them.
+4. **Wait for review and merge by the user.** Claude does not merge.
+5. After merge, move the Linear issue to **Done** and delete the branch.
+
+---
+
+## CI — two lanes
+
+Game builds are slow. A full cook and package is tens of minutes and gigabytes; running that
+per-PR would make CI something to route around, and CI that gets routed around is worse than
+none.
+
+| | Lane 1 | Lane 2 |
+|---|---|---|
+| **Runs** | Every PR | Weekly, and before any build handed to another person |
+| **Does** | Compile the editor target, `CompileAllBlueprints`, `DieRobot.Settled.*` | Cook + package Development and Shipping, capture a perf trace on a scripted wave |
+| **Budget** | Minutes | As long as it takes |
+| **Blocks merge** | Yes | No — it opens issues |
+
+Lane 1 is the merge gate. Lane 2 is the early-warning system: a cook that breaks is found
+within the week rather than on the day a demo is due.
+
+> **Currently aspirational.** There is no `.github/` in this repo. Setup Brief Phase 1 lands
+> Lane 1. Until then, L.1's compile gate and C.2's smoke pass **are** the CI — run by hand,
+> and the standard does not drop because the runner is a person.
+
+---
+
+## The EXP lane
+
+Experimental code and content — a mechanic being tried, a tuning pass being felt out, a
+prototype that exists to answer a design question.
+
+**Exempt from:** L.2 (tests), L.3 (performance), L.4 (code review).
+
+**Never exempt from:** having a Linear issue, a branch, a commit message that says what it
+is, and an answer at the end.
+
+Rules:
+
+- Branch is named `exp/<short-name>`. Never `die-XX`.
+- The commit body states the **question being answered**, not just the change.
+- **An EXP branch never merges to `main`.** It is either graduated — reimplemented on a
+  `die-XX` branch taking every step — or deleted. There is no third option, because the
+  exemption is what makes it fast, and merging exempt code is how a codebase acquires a
+  region nobody will touch.
+- Every EXP branch gets a written answer in the vault's Open Questions & Graveyard. **An
+  experiment with no recorded answer was not an experiment; it was a detour.**
+
+The exemption exists because infrastructure must never be the reason a design question goes
+unanswered. Setup Brief §8 states it directly: if an experiment is waiting, the cheat manager
+and firing range outrank all CI work.
+
+---
+
+## Active Agents
+
+| Agent | Step | Role |
+|---|---|---|
+| `test-writer` | L.2 | Writes UE Automation tests for code that just landed |
+| `performance-reviewer` | L.3 [BLOCKING] | Audits frame-time and allocation cost; flags growth |
+| `linear-task-reviewer` | C.3 | Verifies the work against the task it came from |
+
+**Deliberately absent.** No `security-auditor` — see CLAUDE.md → Claude Setup for why a
+security audit of a single-player offline game is theatre. If Die Robot ever ships
+multiplayer, leaderboards that accept client-authored scores, or user-generated content,
+that decision is reopened and this line is the reminder to reopen it.

--- a/.claude/agents/linear-task-reviewer.md
+++ b/.claude/agents/linear-task-reviewer.md
@@ -1,0 +1,116 @@
+---
+name: linear-task-reviewer
+description: Use at close-out, once every logical change is committed and before the PR is opened — step C.3 of .claude/WORKFLOW.md. Compares the Linear issue against the full branch diff and the smoke result, checking every Success Criterion and surfacing drift in both directions. Reports; never edits code and never silently edits the issue.
+tools: Read, Glob, Grep, Bash
+---
+
+# Agent: linear-task-reviewer
+
+You verify that the work matches the task it came from. You run at step C.3 of close-out —
+after the smoke pass, before the full-PR code review — and your job is to catch the gap
+between what was asked for and what was built, while it is still cheap to fix.
+
+You are not a code reviewer. You do not assess whether the code is good. You assess whether
+it is **the thing that was asked for**, all of it, and nothing else.
+
+## Inputs
+
+1. The Linear issue(s) — fetch via the Linear MCP tools. Read the full description: Summary,
+   Intent, Goals, Technical Spec, Expected Result, Success Criteria.
+2. The full branch diff — `git diff $(git merge-base origin/main HEAD)..HEAD`
+3. The commit messages on the branch — `git log --format='%B' origin/main..HEAD`
+4. **The smoke result from WORKFLOW C.2.** For a gameplay issue this is evidence, not
+   commentary — see below.
+
+## What you check
+
+### Every Success Criterion, one at a time
+
+For each checkbox, state: **met / not met / cannot verify**, and the evidence.
+
+"Cannot verify" is a legitimate and important verdict. A criterion like *"Lola's health bar
+drops on a melee hit"* is not verifiable from a diff — it is verifiable from the smoke
+result. If the smoke result does not mention it, the criterion is **not met**, and saying so
+is the entire value of this step.
+
+**Do not accept a compile-and-tests result as evidence for a playable criterion.** The
+project's own history is the argument: DIE-24 passed every static check available for eight
+sessions.
+
+### Drift in both directions
+
+| Direction | What it looks like | What to do |
+|---|---|---|
+| **Under-delivery** | An Expected Result artifact that does not exist in the diff | Name it. Either it gets built, or the issue is edited to say it was dropped and why. |
+| **Over-delivery** | Work in the diff that no criterion asked for | Name it. Either a criterion is added, or a separate issue is filed, or it comes out. |
+
+Over-delivery is the one that gets waved through, and it is the one that makes a PR
+un-reviewable and a Linear board fiction. A refactor that rode along inside a bug fix is
+scope drift even when it is an improvement.
+
+**Drift is never left unnoted.** Resolving it means updating the issue, filing a new one, or
+removing the work — a fourth option does not exist.
+
+### Goals vs. mechanism
+
+`Goals` are stated without mechanism, so check them as capabilities: is the capability
+actually there, in the general case? An issue whose goal is *"a new enemy type inherits
+working damage without extra wiring"* is not met by a fix that special-cases one boss.
+
+### Intent
+
+Read `Intent` last and ask whether the larger thing it describes actually moved. This catches
+the technically-complete-but-pointless outcome — every criterion ticked while the reason the
+work existed is untouched.
+
+Where `Intent` names a pillar or decision (`Serves P1`, `Violates D4`), check that
+relationship specifically. If the change was supposed to remove a design violation and the
+violation is still there, that is the finding.
+
+### The issue's own quality
+
+If the issue is missing sections, has vague criteria, or has criteria nobody could mark
+without an opinion, say so. A criterion that reads *"boss damage works correctly"* cannot be
+checked, and the right outcome is a rewritten criterion — not a generous interpretation.
+
+**Flag `\n` damage.** If the description contains literal `\` `n` characters, it was written
+through an escape sequence and renders as garbage. Report it for repair.
+
+## What you do not do
+
+- **You never edit code.**
+- **You never silently edit the Linear issue.** Propose the exact edit and let the user
+  decide. An agent quietly rewriting the criteria it is measuring against defeats the step.
+- You do not review code quality, style, or performance — those are the `code-review` skill
+  and `performance-reviewer`.
+- You do not pass something because it is close. The gate is every Success Criterion met.
+
+## Output format
+
+```
+Agent: linear-task-reviewer
+Issue(s): DIE-XX [, DIE-YY]
+Verdict: MET | GAPS
+
+Success Criteria
+- [x] <criterion> — met. Evidence: <commit / file / smoke observation>
+- [ ] <criterion> — NOT MET. <what is missing>
+- [?] <criterion> — cannot verify. <what evidence would settle it>
+
+Goals
+- <goal> — met as a general capability | met only for the specific case | not met
+
+Intent
+- <one line: did the larger thing move?>
+
+Drift
+- Under-delivery: <expected artifact absent from the diff>
+- Over-delivery: <work present that no criterion asked for> → <add criterion | file issue | remove>
+
+Issue quality
+- <missing sections, unverifiable criteria, \n damage, proposed edits>
+```
+
+Verdict is **GAPS** if any criterion is not met or cannot be verified, or if any drift is
+unresolved. Close-out does not proceed to the PR on a GAPS verdict without the user
+explicitly deciding what to do about each one.

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -1,0 +1,173 @@
+---
+name: performance-reviewer
+description: Use before committing any change that touches a per-frame or per-enemy path — Tick, behavior tree tasks and services, AI, combat, navigation, status effects, wave spawning, synergy, or anything on the ultra risk bar — step L.3 of .claude/WORKFLOW.md, where its findings block the commit. Audits frame-time and allocation cost against .claude/rules/unreal-style.md and flags when a cost is growing structurally. Reports; never edits.
+tools: Read, Glob, Grep, Bash
+---
+
+# Agent: performance-reviewer
+
+You are a game engineer whose job is to keep Die Robot's frame time honest. You run at step
+L.3 of the change loop in `.claude/WORKFLOW.md` — after `test-writer`, before the pre-commit
+code review — and your findings block the commit.
+
+**Frame time is a feature.** A change that is correct and costs 4 ms on the enemy tick is not
+done. In a game where the design target is dozens of enemies converging on an authored kill
+path, cost is part of the diff — and it is the part no one can see by reading it.
+
+You replace what would be a security auditor in a networked product. Die Robot is
+single-player and offline: no auth, no PII, no server, no untrusted input. Auditing a trap
+damage calculation for injection is theatre. Auditing it for per-hit allocation is not.
+
+You operate in two modes simultaneously: **tactical** (does this change cost more than it
+should?) and **strategic** (is a cost growing in a way the current design won't hold?).
+
+## Authoritative rules
+
+`.claude/rules/unreal-style.md` (Tick, containers, const-correctness, spawning) and
+`.claude/rules/architecture.md` (layer order, subsystem lifetimes). Read them before
+auditing. If a rule is unclear or under-specified, that is a finding — flag it.
+
+The vault's `02 Technical/Systems Inventory.md` records which systems are already known to be
+hot and why. Read it rather than rediscovering.
+
+## Tactical scope
+
+### Per-frame paths — the primary target
+
+- `TickComponent`, `Tick`, `TickActor` in anything under `Components/`, `Character/`, `AI/`
+- Behavior tree `Tasks/` and `Services/` — services re-run on an interval, per enemy
+- Anything called from those
+
+Look for:
+
+- **`bCanEverTick = true` with a body that does nothing** but call `Super`. That is a
+  registration and a virtual call per frame per instance for no work. `UCombatComponent`
+  currently does this — flag any new instance of it.
+- **Allocation in a tick body** — `TArray` construction, `FString` formatting, `TMap`
+  creation, any `new`. Per-frame allocation is the most common real regression here.
+- **`GetAllActorsOfClass`, `FindComponentByClass`, `GetComponentsByClass`** anywhere on a
+  per-frame path. These are linear scans over the world. Cache in `BeginPlay`.
+- **Logging at `Log` or above in a tick body.** The string format costs even when the output
+  is filtered out.
+- **Work that should be a timer or an event.** `SetTimer` for periodic, a delegate or
+  `MissionEventSubsystem` for reactive. Ask whether tick is the right mechanism at all, not
+  just whether the tick body is cheap.
+
+### Per-enemy scaling
+
+The design puts many enemies on screen converging on one path. Anything per-enemy multiplies.
+
+- Cost per enemy × the wave's enemy count — state the multiplication explicitly in findings
+- Status effect application and expiry (`Components/StatusEffect/`)
+- Synergy evaluation (`Subsystems/SynergySystem/`) — tag container comparisons per hit
+- Damage application (`Components/Combat/`)
+
+### Navigation — the known-weakest system
+
+- Repeated nav queries where one would do. The double nav query and the 228-query worst case
+  in `FindClosestAccessiblePoint` are already recorded — flag anything that adds to that
+  pattern.
+- Path recalculation frequency. A full repath per enemy per frame is a cliff.
+- `FNavMeshPath::PathCorridor` access in `Task_MoveThroughCorridorPathV2` is deliberate and
+  sophisticated; it is also engine-internal. Cost changes there matter more than most.
+- Navmesh rebuild triggers. `RuntimeGeneration=Dynamic` with small tiles is a deliberate
+  trade for responsive building — flag anything that widens what a single wall placement
+  dirties.
+
+### Spawning and destruction
+
+- `SpawnActor` in a loop — it overlap-sweeps against existing actors, so a loop is quadratic.
+  This is DIE-26 in `LoadBuildableData`. Flag new instances.
+- Missing `ESpawnActorCollisionHandlingMethod::AlwaysSpawn` where placement is already
+  validated.
+- Destruction re-entrancy — DIE-16 is a missing death guard causing double loot and wave
+  counter drift. A guard is correctness *and* cost.
+
+### Load time and hitching
+
+- Anything added to a `BeginPlay` or subsystem `Initialize` that scales with content size
+- Synchronous asset loads on a gameplay path — prefer `TSoftObjectPtr` and async load
+- Niagara system spawning in bursts. Known to correlate with observed hitches.
+- New materials or shader permutations — a new permutation is a compile stall the first time
+  it is seen, on every machine that has not cached it
+
+### Memory and containers
+
+- `TArray::Add` in a loop without `Reserve()`
+- Copying structs by value in a range-for. `FBuildableData` carries ten directional GUIDs —
+  copying it in a loop is not free.
+- Linear `TArray` search where a `TMap` belongs, on any repeated path
+
+## Strategic mode
+
+Beyond this diff: is a cost growing in a way the current design will not hold?
+
+Raise an **EXPAND** finding when you see:
+
+- A per-frame cost that is fine at today's enemy counts but not at the design's target
+- A system acquiring per-instance state that will not survive being multiplied
+- A pattern being copied — the second and third instance of a costly idiom is when it becomes
+  the codebase's convention
+- Growth that argues for a structural answer (object pooling, a shared subsystem tick, LOD on
+  behavior, spatial partitioning) rather than another local fix
+- The absence of measurement where a guess is being made
+
+EXPAND findings do not block. They are recorded, carried into WORKFLOW C.5, and usually
+become a vault Decision Log entry or a new Linear issue.
+
+## Measurement
+
+You cannot profile from a diff, and you must not pretend to.
+
+- **Reason about cost structurally** — order of growth, allocation per call, calls per frame,
+  instances per wave. Say `O(n²) over buildables, n≈40 today` rather than a fabricated
+  millisecond figure.
+- **Never invent numbers.** A made-up "this costs 3 ms" is worse than "this allocates once
+  per enemy per frame; measure it" because it survives into a decision.
+- When a finding needs real measurement to settle, say so and name the tool: `stat unit`,
+  `stat game`, `stat navigation`, Unreal Insights, or `Trace` on a scripted wave. That is
+  Lane 2 CI's job — see `WORKFLOW.md` → CI.
+
+## Severity
+
+| Level | Means |
+|---|---|
+| **BLOCK** | A per-frame allocation, an added O(n²), an unbounded query, or a new tick doing no work. Halts the loop — return to L.1. |
+| **WARN** | A real cost that is acceptable today but should be recorded. Fix or write down why not. |
+| **EXPAND** | Strategic. Does not block; carries into close-out. |
+| **NOTE** | Observation worth the author knowing. |
+
+## What you do not do
+
+- **You never edit.** You report. The implementer fixes.
+- You do not review correctness, style, or naming — that is the `code-review` skill at L.4.
+- You do not review security. There is no attack surface here; if that changes (multiplayer,
+  server-validated leaderboards, user-generated content), say so as an EXPAND finding, because
+  that is the trigger to reopen the decision not to have a security auditor.
+- You do not block on speculative cost. "This might be slow" without a mechanism is a NOTE.
+
+## Output format
+
+```
+Agent: performance-reviewer
+Verdict: PASS | FINDINGS
+Scope audited: [paths]
+
+BLOCK
+- [file:line] What the cost is, its structure (per frame / per enemy / per spawn),
+  and what it multiplies by. What to do instead.
+
+WARN
+- [file:line] ...
+
+EXPAND
+- [what is growing] Why the current shape won't hold, and the structural option.
+
+NOTE
+- ...
+
+Not audited: [anything in the diff you deliberately skipped, and why]
+```
+
+If the change touches nothing on a hot path, say so in one line and return PASS. A stated
+skip is the point; a silent one is not.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -1,0 +1,187 @@
+---
+name: test-writer
+description: Use after implementation code has landed but before it is reviewed or committed — step L.2 of .claude/WORKFLOW.md. Writes UE Automation tests that lock in the behavior the new code just established, and runs them. Not for writing gameplay code, and not for tests-first work; the implementation exists already.
+tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Agent: test-writer
+
+You are a senior test engineer working in Unreal Engine 5.8. You write tests **after** the
+code they cover has been written, before any review agent runs. Your tests document the
+contract the code satisfies and catch regressions on the next change.
+
+## The situation you are walking into
+
+**This project has zero automated tests.** `Private/Tests/TestObj.cpp` is not a test — it is
+a shipped interactable lever that early-starts a wave. The folder name is currently a lie.
+
+That is not an excuse to skip; it is the reason you exist. Three of the bugs found during the
+5.8 recovery were invisible to code review and only findable by running the game. DIE-24 — the
+save-doubling bug that reached 20,736 entries and froze the editor — survived eight sessions
+and would have fallen to **one save/load round-trip test**.
+
+So: a change to a system with no tests is the opportunity to give it some, not a reason to
+skip the step. You are building the `DieRobot.Settled.*` suite one system at a time, starting
+with whatever the current change touched.
+
+## Your role
+
+Write tests for the code that just landed in the current task. The implementer has already
+written the code — lock its behavior in. **If the test you'd write fails against the new
+code, the code is wrong, not the test.** Say so; do not weaken the test to make it pass.
+
+## The suite
+
+Every test lives under the `DieRobot.Settled.` namespace, then the system, then the behavior:
+
+```
+DieRobot.Settled.SaveLoad.BuildableRoundTripPreservesCount
+DieRobot.Settled.SaveLoad.RepeatedSaveDoesNotGrowArray
+DieRobot.Settled.Combat.BossTakesDamageFromMelee
+DieRobot.Settled.Synergy.FirstEffectApplicationSucceeds
+DieRobot.Settled.Wave.CompositionMatchesDataTable
+```
+
+**"Settled" means armored by tests.** The vault currently marks four systems SETTLED that
+have no coverage at all — the label is aspirational until this suite exists. When you land
+tests that genuinely armor a system, that is a vault update; flag it for WORKFLOW C.5.
+
+## How you write tests
+
+### Structure
+
+Unreal's automation framework, in files under `Source/DieRobot/Private/Tests/`:
+
+```cpp
+// Property of Paracosm.
+
+#include "Misc/AutomationTest.h"
+#include "Subsystems/SaveLoad/SaveLoadSubsystem.h"
+
+/**
+ * Verifies that saving twice without changing anything leaves the buildable
+ * array the same size.
+ * Pass:  count after the second save equals the count after the first.
+ * Fail:  the array grew — SaveBuildableData is appending to a pre-populated
+ *        array, which is DIE-24 reintroduced.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FSaveLoadRepeatedSaveTest,
+    "DieRobot.Settled.SaveLoad.RepeatedSaveDoesNotGrowArray",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSaveLoadRepeatedSaveTest::RunTest(const FString& Parameters)
+{
+    // Arrange
+
+    // Act
+
+    // Assert
+    TestEqual(TEXT("buildable count after second save"), SecondCount, FirstCount);
+    return true;
+}
+```
+
+**Check the flag names against the engine headers before writing.** `EAutomationTestFlags`
+became a scoped enum in recent versions and the constant names have moved between releases —
+read `Engine/Source/Runtime/Core/Public/Misc/AutomationTest.h` in the 5.8 install rather than
+writing them from memory.
+
+For anything needing a loaded world, use the complex/latent forms —
+`IMPLEMENT_COMPLEX_AUTOMATION_TEST` and `ADD_LATENT_AUTOMATION_COMMAND` — and open a map with
+`AutomationOpenMap`. **Say so explicitly when a test needs a world fixture that does not exist
+yet**; building one is a deliberate decision, not something to smuggle into a bug fix.
+
+### Naming
+
+Every test name describes the scenario and expected outcome:
+
+- `RepeatedSaveDoesNotGrowArray` — not `SaveTest2`
+- `BossTakesDamageFromMelee` — not `TestBoss`
+- `FirstEffectApplicationSucceeds` — not `StatusEffectTest`
+
+### Comments
+
+Every test gets a 3–5 line comment block above it stating what it verifies and what each
+outcome means. Name the issue ID when the test guards a specific fixed bug — a test whose
+purpose is remembered is one nobody deletes during a refactor.
+
+### Assertions
+
+- `TestEqual`, `TestTrue`, `TestFalse`, `TestNotNull`, `TestValid` — always with a descriptive
+  message string, because a failure report with no message is a line number and nothing else.
+- One behavior per test. Don't bundle unrelated assertions.
+- Arrange-Act-Assert with blank lines between phases.
+
+## What to test first
+
+Priority order, because coverage has to start somewhere:
+
+1. **Anything with a recorded bug ID.** DIE-12 through DIE-26 are known-broken. A test that
+   fails today, documents the bug, and passes when it is fixed is worth more than a test of
+   working code.
+2. **Save/load round-trips.** The least forgiving surface in the project — versioned by
+   nothing, read on every level load, and a bad write is found by a player weeks later as a
+   lost base.
+3. **Pure functions and data transforms.** Damage math, wave composition from a DataTable,
+   loot roll distribution, tag combination in the synergy rules. These need no world and are
+   cheap to write.
+4. **Invariants that hold across a system.** "Every element has three tiers", "every effect
+   in the DataAsset has a non-zero duration" — data validation tests catch content mistakes
+   the compiler never sees.
+
+## What you cannot test, and must say so
+
+Be honest about the boundary rather than writing a test that only appears to cover something.
+
+- **Blueprint graph logic** — not reachable from C++ automation. Its verification is the smoke
+  pass at WORKFLOW C.2.
+- **Anything needing rendering, VFX, or animation to be observed** — a screenshot comparison
+  is a Lane 2 concern, not a unit test.
+- **Feel, pacing, and balance** — these are design questions answered by playing, and the
+  vault's Open Questions is where they live.
+- **Navmesh generation and pathing quality** — needs a built world; possible, but it is a
+  fixture investment to decide on deliberately.
+
+When the change you are covering falls into one of these, **write that down as your output
+rather than producing a hollow test.** A test that mirrors the implementation 1:1 catches
+nothing and creates false confidence, which is worse than a stated gap.
+
+## Running them
+
+```powershell
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -ExecCmds="Automation RunTests DieRobot.Settled" -unattended -nopause -nosplash -testexit="Automation Test Queue Empty"
+```
+
+The editor must be closed first, and the module must compile. **Run them and report the real
+result** — never claim a test passes without the output in front of you.
+
+## Coverage philosophy
+
+- **High coverage on tests that matter.** For each function under test, ask: "If I broke this,
+  would this test fail?" If no, the test is wrong.
+- A test that would have caught a real bug in this project's history is worth its weight. A
+  test that only catches a refactor is overhead.
+- Adding a test to `Private/Tests/` means confronting that `TestObj.cpp` is sitting there
+  pretending to be one. Moving it out is a small, separate, welcome commit — not something to
+  bundle.
+
+## Output format
+
+```
+Agent: test-writer
+Tests written: [count]
+Suite: DieRobot.Settled.[System].*
+
+Covered:
+- [test name] — what it locks in, and the bug ID it guards if any
+
+Run result:
+- [actual command output — pass/fail counts]
+
+Not covered, and why:
+- [behavior] — [Blueprint logic / needs world fixture / design question]
+
+Fixture gaps:
+- [anything that would need building before a whole class of tests is possible]
+```

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,249 @@
+# Architecture Rules — Die Robot
+
+One C++ module, `DieRobot`, plus a large Blueprint and content layer. ~29k lines across
+~150 classes.
+
+For *what each system currently does and what state it's in*, read the vault's
+`02 Technical/Systems Inventory.md`. This file is the **layout and layering contract** — where
+new code goes and what may depend on what.
+
+---
+
+## Module layout
+
+Standard Unreal `Public/` (headers) and `Private/` (implementation) split. **The two trees
+mirror each other folder-for-folder.** A header at `Public/Components/Combat/CombatComponent.h`
+has its implementation at `Private/Components/Combat/CombatComponent.cpp`. Breaking the mirror
+is how files become unfindable.
+
+```
+Source/DieRobot/
+├── DieRobot.Build.cs
+├── Public/            # Headers — mirrors Private/ exactly
+└── Private/
+    ├── AI/            # Controllers, behavior tree Tasks/ and Services/
+    ├── BuildSystem/   # Buildables: BuildableBase, BuildingComponents, Ramps, Traps, Constructs
+    ├── Character/     # Player and Enemies/ (incl. Boss/)
+    ├── Components/    # BuildSystem, Combat, Inventory, MissionDelivery, Navigation,
+    │                  #   StatusEffect, Vignette — the behavior layer
+    ├── Controller/    # PlayerController
+    ├── Core/          # Module-wide plumbing
+    ├── Data/          # DataAssets/ and DataTable row types
+    ├── Environment/   # World actors
+    ├── GameModes/     # GameMode, GameState
+    ├── Interfaces/    # UINTERFACE contracts
+    ├── Loot/          # Loot tables, drops
+    ├── Settings/      # Developer settings
+    ├── States/        # PlayerState
+    ├── Subsystems/    # SaveLoad, Wave, SynergySystem, Events, Music, SFX, Online,
+    │                  #   Dialogue, GameConfig — the service layer
+    ├── Synergy/       # EffectLogic/DerivedHandlers/ — per-effect logic
+    ├── Tests/         # ⚠ Currently contains no tests. See below.
+    ├── Types/         # Shared enums and structs
+    ├── UI/            # Widgets
+    ├── ViewModels/    # MVVM view models
+    └── Weapons/       # Weapons and Abilities/
+```
+
+> **`Private/Tests/TestObj.cpp` is not a test.** It is a shipped interactable lever that
+> early-starts a wave. Do not read it as coverage, and do not put real tests beside it
+> without moving it first — the folder name is currently a lie.
+
+## Where new code goes
+
+| You're adding... | It goes in... |
+|---|---|
+| Per-actor behavior attachable to more than one owner | `Components/` |
+| A world-lifetime or game-lifetime service | `Subsystems/` |
+| A placeable thing the player builds | `BuildSystem/` |
+| A new element, tier, or emergent effect | `Synergy/EffectLogic/DerivedHandlers/` |
+| Enemy decision-making | `AI/Behavior/Tasks/` or `Services/` |
+| Tunable data (a trap, a wave, a loot table, a mission) | `Data/DataAssets/` — **not** a new class |
+| A contract two unrelated classes share | `Interfaces/` |
+| A struct or enum used across folders | `Types/` |
+
+**The default answer for new content is a DataAsset, not a class.** Traps, waves, effects,
+missions, loot and dialogue are already data-driven. If adding an enemy variant or a trap
+requires a C++ edit, that is a design finding to raise — not a task to quietly complete.
+
+---
+
+## Where tests go
+
+**`Private/Tests/`, inside this module** — Epic's own convention, used throughout the engine
+(`Core/Private/Tests/`, `AIModule/Private/EnvironmentQuery/Tests/`, `CoreOnline/Private/Tests/`).
+
+Not a separate test module, for three reasons:
+
+- **Tests need private headers.** Nearly everything worth testing — `USaveLoadSubsystem`,
+  `UBuildSystemManagerComponent`, the synergy handlers — is in `Private/`. A separate module
+  cannot see them without exporting, and exporting production classes because the test tooling
+  demands it lets the harness redesign the code.
+- **Test code does not ship.** The automation macros are wrapped in `#if WITH_AUTOMATION_TESTS`
+  (`Misc/AutomationTest.h`), which is 0 in Shipping and Test. They compile to nothing in a
+  packaged build, so the usual reason to isolate tests does not apply.
+- No extra `Build.cs`, `.uproject` module entry, or target to maintain.
+
+**Mirror the source tree inside `Tests/`**, the same way `Public/` mirrors `Private/`:
+
+```
+Private/Tests/
+  SaveLoad/SaveLoadSubsystem.spec.cpp
+  Combat/DamageCalculation.spec.cpp
+  Synergy/EffectCombination.spec.cpp
+  Wave/WaveComposition.spec.cpp
+```
+
+There is no `Public/Tests/` — nothing includes a test.
+
+### Two forms, both used by Epic
+
+| Form | For |
+|---|---|
+| `*.spec.cpp` — `DEFINE_SPEC`, Describe/It | **The default.** Shared fixtures, nested structure. Epic uses it in `Json/Private/Tests/` and `BuildPatchServices/Private/Tests/Unit/`. |
+| `IMPLEMENT_SIMPLE_AUTOMATION_TEST` in a plain `.cpp` | One-off invariant checks with no shared setup. |
+
+Spec form is the default for `DieRobot.Settled.*`: the suite needs shared fixtures (a world, a
+populated save), and the Describe nesting maps onto the `System.Behavior` naming directly.
+
+### Functional tests are content, and they are committed
+
+Tests needing a running world with real actors are Blueprint actors placed in a test map. Those
+live in **`Content/Maps/Tests/`**, committed like any other content.
+
+**They must not live in a gitignored `Content/Developers/` scratch area** — CI could never run
+them. The Developers folder is for throwaway experiment assets; a committed test fixture is a
+different thing.
+
+The dividing line: **needs a world with actors → functional test in a map. Pure logic → C++ in
+`Private/Tests/`.**
+
+### Before the first real test lands
+
+`Private/Tests/TestObj.cpp` has to move to `Private/Debug/`. It is a shipped gameplay actor —
+unguarded by `WITH_AUTOMATION_TESTS` — sitting in a folder named Tests. Its eventual neighbour
+is the cheat manager the Setup Brief calls for. Its own small commit, not bundled with a test.
+
+---
+
+## Layer order
+
+Dependencies point **downward only**. A layer may know about layers below it, never above.
+
+```
+UI / ViewModels          ← reads state, sends intent; owns no game logic
+        ↓
+Components               ← per-actor behavior (combat, build, mission, nav, status)
+        ↓
+Subsystems               ← world/game services (save, wave, synergy, events)
+        ↓
+Data / Types / Interfaces ← DataAssets, structs, enums, contracts. Depends on nothing.
+```
+
+Rules that follow from this:
+
+- **A Subsystem never reaches up into a Component to drive it.** It emits an event or exposes
+  state the Component reads. `MissionEventSubsystem` is the model to copy: combat broadcasts a
+  tagged event, missions subscribe declaratively, and neither knows the other exists.
+- **A Component may talk to a Subsystem** via `GetWorld()->GetSubsystem<T>()` or the game
+  instance. That direction is fine.
+- **UI never mutates game state directly.** It goes through a ViewModel to a Component or
+  Subsystem. `ViewModels/` exists to make this the path of least resistance.
+- **`Data/`, `Types/` and `Interfaces/` depend on nothing in the module.** If a DataAsset needs
+  to include a Component header, the data and the behavior are tangled — that is the finding.
+
+### Sideways dependencies are the real hazard
+
+Component-to-component coupling is what makes systems un-testable and un-migratable. The
+standing example is in `Components/StatusEffect/`:
+
+> `UStatusEffectHandlerComponent` hard-casts its owner to `ADieRobotEnemyCharacter`. That single
+> cast is why **status effects cannot apply to the player, the Seeda, or buildables** — no burning
+> player, no frozen Seeda. A whole class of design space is closed by one `Cast<>`.
+
+When a component needs something from its owner, express it as an **Interface** the owner
+implements, not a concrete cast. A cast to a concrete class in a component is a design decision
+about what that component can ever be attached to — make it deliberately or not at all.
+
+---
+
+## GameplayTags are the cross-system vocabulary
+
+Tags are pervasive already, defined in `Config/Tags/` (see `SynergySystemTags.ini`). They are
+how systems refer to each other's concepts without linking against each other's headers.
+
+- **Prefer a tag to an `IsA` ladder.** The standing anti-example is
+  `PopulateCombatEventContextTags`, which decides an enemy's event tag by walking a chain of
+  `IsA` checks — so adding an enemy type requires editing C++. It should read a tag off the
+  asset.
+- Tag names are a public interface. Renaming one breaks Blueprints and DataAssets silently, and
+  there is no compiler to catch it.
+- This pervasiveness is why the GAS migration is well-positioned: GAS's whole coordination model
+  is tags, and the vocabulary already exists.
+
+---
+
+## Events over polling
+
+`Subsystems/Events/MissionEventSubsystem` is the best-designed thing in the codebase and the
+pattern to reach for. Combat emits `Event.Combat.Damage` with a `FGameplayTagContainer` of
+context tags; missions subscribe to what they care about. Neither side knows the other.
+
+That is roughly 80% of what GAS's GameplayEvent layer does, already built. When two systems need
+to coordinate, the question is "what event describes this?" before "what pointer do I need?"
+
+---
+
+## Subsystem lifetimes
+
+Pick the narrowest that works, and know which you picked:
+
+| Type | Lives for | Use when |
+|---|---|---|
+| `UGameInstanceSubsystem` | The whole process, across level travel | State must survive a level change (Wave, SaveLoad, Online) |
+| `UWorldSubsystem` | One level | State is meaningless in another level |
+| `ULocalPlayerSubsystem` | One local player | Per-player, e.g. input or HUD state |
+
+> **Anything cached across level travel in a GameInstance subsystem is a latent bug** until
+> proven otherwise. A `UAudioComponent` held by the music subsystem across travel is a known
+> live example — the actor it belonged to is gone, the pointer is not.
+
+---
+
+## The Build.cs is a dependency contract
+
+`DieRobot.Build.cs` lists `PublicDependencyModuleNames` only. Adding a module there is a real
+architectural decision — it grows compile time for every translation unit and takes on an engine
+API surface.
+
+Current dependencies: Core, CoreUObject, Engine, InputCore, EnhancedInput, UMG, SlateCore, Slate,
+Niagara, MetasoundEngine, GameplayTags, NavigationSystem, ModelViewViewModel, and the online
+stack (OnlineServicesInterface, CoreOnline, OnlineServicesCommon, OnlineServicesEOS).
+
+- **Prefer `PrivateDependencyModuleNames`** for anything not appearing in a public header. It
+  keeps the dependency out of every downstream include.
+- **`GameplayAbilities`, `GameplayTasks` and `GameplayAbilities`' friends are the GAS migration's
+  first commit** — adding them is on the ultra risk bar.
+- Both OSSv1 and OSSv2 plugins are currently enabled. Picking one is outstanding work, not a
+  settled state.
+
+---
+
+## Blueprint is a leaf, not a layer
+
+Restated from CLAUDE.md because it is an architectural rule, not a style preference:
+
+**C++ can be diffed, reviewed and tested. Blueprint can be none of the three.** Logic in a
+Blueprint leaves no trace in the history and cannot be regression-tested.
+
+| Belongs in Blueprint | Belongs in C++ |
+|---|---|
+| Composition — which components, which meshes | Logic other systems depend on |
+| Tuning values and curves | Anything with a state machine |
+| Presentation, animation hookup, VFX triggers | Anything on a per-frame path |
+| Widget layout | Anything worth a test |
+
+A Blueprint may call into C++ freely. **C++ should not depend on logic that only exists in a
+Blueprint** — that inverts the layering and puts the un-reviewable half underneath.
+
+See `rules/content-changes.md` for what a Blueprint change owes a reviewer.

--- a/.claude/rules/content-changes.md
+++ b/.claude/rules/content-changes.md
@@ -1,0 +1,140 @@
+# Content Change Rules — Die Robot
+
+Everything under `Content/` is a binary `.uasset` or `.umap`. **`git diff` shows nothing.**
+`git log -p` shows nothing. The `code-review` skill cannot read it. A reviewer opening the
+PR sees a filename and a byte count.
+
+This is the single largest structural difference between working in this repo and working in
+a normal codebase, and every rule here follows from it.
+
+---
+
+## The core rule
+
+**A content change is only reviewable if the person who made it describes it.** There is no
+fallback, no tooling that recovers the information, and no way to reconstruct it later. The
+description *is* the diff.
+
+Nobody — including you, in three weeks — can otherwise answer "what changed in
+`BP_SpikeTrap` in that commit?"
+
+---
+
+## The evidence package
+
+Every commit touching `Content/` carries:
+
+### 1. A per-asset statement of what changed
+
+Not "updated the trap." Name each asset and what changed inside it:
+
+```
+## What changed
+- Content/Blueprints/Traps/BP_SpikeTrap.uasset — base damage 25 → 18;
+  added Effect.Corrosion.Erode to the applied effect container; retriggerable
+  cooldown 1.2s → 0.8s
+- Content/Data/DT_WaveComposition.uasset — wave 7 row: Bruiser count 4 → 6
+- Content/Maps/L_Lab.umap — moved RecastNavMesh-Regular to world origin
+```
+
+Numbers matter. "Reduced the damage" is not recoverable; `25 → 18` is.
+
+### 2. Visual evidence for anything visible
+
+A screenshot or a short clip, attached to the PR, for any change to:
+
+- Materials, VFX, Niagara systems, lighting
+- Level geometry or layout
+- UI widgets
+- Animation or montages
+
+Prose cannot carry these. A screenshot is the only artifact that answers "does this look
+right."
+
+### 3. A smoke result for anything functional
+
+A Blueprint graph change, a DataAsset value change, a DataTable row — these have no visual
+and no unit test. Their verification is running the game and saying what happened. State
+which smoke sections you ran.
+
+**A content commit with none of the three is not a reviewed commit.** It is a byte count
+with a hopeful message.
+
+---
+
+## Never commit content you cannot describe
+
+If you did not make the change and cannot say what is inside it, do not commit it. Two cases
+recur:
+
+**The editor touched files you didn't edit.** Opening a map or asset can re-save it —
+recomputed lighting, a rebuilt navmesh, a bumped asset version. These show as modified with
+no intent behind them. Check `git status` before staging and **revert what you did not mean
+to change**. Committing an editor-incidental resave hides a real change in the noise the
+next time.
+
+**A resave or migration commandlet ran.** That is legitimate, but it is its own commit with
+its own message stating what ran and why — never bundled with a gameplay change.
+
+---
+
+## LFS is permanent
+
+`Content/` is LFS-tracked. The repo sits at ~14.8 GB against a 10 GB Pro allowance, metered
+at $0.07/GB/month.
+
+- **Every version of every asset is stored forever.** A 200 MB asset re-saved ten times is
+  2 GB stored, permanently.
+- Gitignoring something later **caps future growth and reclaims nothing.**
+- `Content/SourcedAssets/` (~6.1 GB) is purchased marketplace art, re-downloadable from Fab.
+  It is the main growth driver and the first thing to think twice about.
+
+**Run `git lfs status` before pushing** and look at what is in the list. A surprise there is
+a bill, not a mistake you can undo.
+
+---
+
+## Blueprint and C++ move together
+
+A C++ change that alters a `UPROPERTY`, `UFUNCTION`, class name, or any reflected signature
+can silently break Blueprints that reference it. **The C++ compiler will not tell you.**
+
+- Run `CompileAllBlueprints` after any such change — it is step L.1's second gate.
+- When a rename is unavoidable, add a `CoreRedirect` in `Config/DefaultEngine.ini` rather
+  than leaving assets to fail. Note that **class redirects resolve before property and
+  function redirects** — a property redirect keyed on an old class name can never fire.
+- If a C++ change requires a Blueprint change, they belong in the **same commit**. Split
+  across two, the repo has a commit where the game does not run.
+
+---
+
+## Merge conflicts in content are unresolvable
+
+There is no three-way merge for a `.uasset`. Git will offer you "ours" or "theirs" and both
+mean discarding someone's work.
+
+Solo, this is mostly avoidable by keeping content branches short and rebasing before
+touching an asset another branch also touched. **When a content conflict does happen, do not
+resolve it mechanically** — pick one version deliberately, re-apply the other change by
+hand in the editor, and say so in the commit body.
+
+Long-lived content branches are the thing that turns this from rare into routine. Keep them
+short.
+
+---
+
+## What belongs in Blueprint at all
+
+From CLAUDE.md → Key Principles: **Blueprint is a leaf, not a layer.**
+
+| Belongs in Blueprint | Belongs in C++ |
+|---|---|
+| Composition — which components, which meshes | Logic other systems depend on |
+| Tuning values and curves | Anything with a state machine |
+| Presentation, animation hookup, VFX triggers | Anything on a per-frame path |
+| Widget layout | Anything worth a test |
+
+The reason is entirely this file's subject: **C++ can be diffed, reviewed, and tested.
+Blueprint can be none of the three.** Logic in a Blueprint is logic that leaves no trace in
+the history and cannot be regression-tested. Put it there only when the alternative is
+worse.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,244 @@
+# Git Workflow Rules — Die Robot
+
+## Never Push to Main
+
+**All work lands on `main` through pull requests.** Never push directly to `main`.
+
+This is a solo project, so the PR is not a gate against a careless colleague — it is a gate
+against yourself at 1am. It creates one place where the diff, the smoke result, and the
+reasoning sit together before anything becomes permanent. Self-merging is expected; skipping
+the PR is not.
+
+- The user reviews and merges every PR — Claude never merges.
+- Lane 1 CI must be green before merge (see `WORKFLOW.md` → CI). Until Lane 1 exists, the
+  L.1 compile gate and the C.2 smoke pass stand in for it.
+
+**The one exception, stated so it is not improvised:** a repository-level emergency where
+`main` itself is broken — a bad merge, a corrupted LFS pointer, a wrong `.gitattributes`.
+Fix it directly, then say so in the commit body. This does not extend to "the change is
+small."
+
+## Branching Strategy
+
+1. Every task or task group gets a branch off `main`.
+2. Each branch gets one PR.
+3. After merge, delete the branch.
+
+**Naming:**
+
+| Kind | Pattern | Example |
+|---|---|---|
+| Single issue | `die-XX` | `die-27` |
+| Grouped issues | `die-XX-short-description` | `die-27-corridor-path-rewrite` |
+| Experiment | `exp/<short-name>` | `exp/primed-threshold` |
+
+Linear auto-links a branch when it finds a full `DIE-XX` identifier with the hyphen. Bare
+numbers and concatenated forms like `die-27-28-29` do not link. When a branch covers several
+issues, name it after the primary one — the rest link via the PR body.
+
+**`exp/*` branches never merge to `main`.** See `WORKFLOW.md` → The EXP lane.
+
+**Claude worktree branches (`claude/*`) are not work branches.** They cannot be linked in
+Linear. If you find yourself on one at S.3, stop and say so.
+
+### Check the branch point
+
+Before starting work, confirm the branch is based on current `origin/main`:
+
+```bash
+git log --oneline -1 origin/main
+git merge-base --is-ancestor origin/main HEAD && echo "up to date" || echo "STALE — rebase first"
+```
+
+This repo has already had a branch sitting eight months behind `main` while work continued
+on it, and a `git checkout main` that silently reverted the entire working directory. With
+8.8 GB of binary content under LFS, a stale branch point is not a style preference.
+
+## Commit Message Format
+
+Every commit follows this structure. The body is **required**.
+
+```
+DIE-XX: imperative subject line under 72 characters
+
+## What changed
+- Concrete bullet of each file/module-level change
+- Be specific: name the file and what was done to it
+
+## Why
+Clear explanation of the motivation. What problem does this solve?
+Include context that won't be obvious from reading the diff.
+```
+
+- Issue ID first, then `: `, then an imperative verb — "add", "fix", "move", "remove",
+  "refactor", "extract", "update"
+- Subject line under 72 characters
+- **No "Co-Authored-By" or any Claude/Anthropic attribution line, anywhere**
+- One logical change per commit
+- Both `## What changed` and `## Why` required
+
+### Content commits carry their own burden
+
+For a commit touching `Content/`, `## What changed` cannot lean on the diff, because there
+is no readable diff. Name each asset and state what changed inside it:
+
+```
+## What changed
+- Content/Blueprints/Traps/BP_SpikeTrap.uasset — damage 25 → 18; added
+  the Corrosion tag to the applied effect container
+- Content/Maps/L_Lab.umap — moved RecastNavMesh-Regular to world origin
+```
+
+"Updated the spike trap" is not a description of a change nobody can read. See
+`rules/content-changes.md`.
+
+### When an exemption is taken
+
+`WORKFLOW.md` allows documentation-only changes and the EXP lane to skip steps. **State the
+exemption in the commit body**, naming which steps were skipped and why the change
+qualifies. An exemption taken silently is how a rule stops meaning anything.
+
+## Every Commit Is Reviewed Before It Lands
+
+**Before each commit**, invoke the **`code-review` skill** on the uncommitted diff. Fix every
+finding, or accept it explicitly in-code with a comment giving the reasoning. Then commit.
+
+The order matters. Reviewing before the commit makes the commit that lands *the reviewed
+artifact*. Reviewing after leaves the reviewed object and the landed object as two different
+things, reconciled only by a follow-up commit or rewritten history.
+
+This is step L.4 of `.claude/WORKFLOW.md`, restated here because it is a commit rule.
+
+Note the mechanism: the **`code-review` skill**, via the Skill tool. Not `/code-review
+ultra` — that is a user-triggered, billed slash command Claude cannot launch, and it appears
+exactly once, at close-out, behind the risk bar.
+
+## Pre-Push Checks
+
+Run these **before every `git push`**. All must pass.
+
+```powershell
+# 1. Close the editor first — UBT cannot replace a loaded DLL.
+
+# 2. Editor target compiles clean
+& "D:\UnrealEngine\UE_5.8\Engine\Build\BatchFiles\Build.bat" DieRobotEditor Win64 Development -Project="C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -WaitMutex
+
+# 3. Every Blueprint still compiles — required whenever a reflected
+#    signature changed (UPROPERTY, UFUNCTION, class name)
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -run=CompileAllBlueprints -unattended -nopause
+
+# 4. The Settled suite (once it exists — Setup Brief Phase 2.3)
+```
+
+Then check what is about to go up:
+
+```bash
+git status --short
+git lfs status
+```
+
+**Look at the LFS list before pushing.** Storage is cumulative and permanent — an asset
+pushed once is stored forever, and gitignoring it later caps growth without reclaiming
+anything. The repo sits at ~14.8 GB against a 10 GB allowance. An accidental
+`Content/SourcedAssets/` addition is a bill, not a mistake you can take back.
+
+## Verify the Push Actually Landed
+
+```bash
+git log --branches --not --remotes --oneline
+```
+
+**Empty output is the only proof.** This is branch-agnostic — it catches unpushed work on
+any branch, not just the current one.
+
+Do not trust the tail of a push's output. A push to this repo has already failed on
+`Connection to github.com closed by remote host` while printing output that read as success.
+Large LFS pushes fail in ways that look like progress.
+
+## PR Description Standard
+
+Every PR body uses these headings:
+
+```markdown
+## Summary
+
+## Test plan
+
+## Linked Issues
+```
+
+The headings are the easy part. What makes a PR description worth reading is the **prose
+under them**, and that is what this section specifies. All three headings with thin content
+does not meet this standard.
+
+### `## Summary`
+
+**One bolded claim per logical change.** Each explains *the failure mode it fixes* — the
+bug, the observable symptom, and why it mattered. Not a description of the diff; the diff is
+already in the PR.
+
+The model:
+
+> **DIE-24 — clear the buildable array before repopulating it.** `SaveCurrentGame()` loads
+> the existing save into the instance before `SaveBuildableData()` appends to it, so every
+> save doubled the array. `InitializeSaveLoadSession()` runs load-then-save on every level
+> entry, so it compounded per visit: a 9-piece base reached 20,736 entries in eight loads,
+> in a 48 MB file that froze the editor for minutes. The symptom looked like a hang at
+> startup with one core pegged, which is why it survived eight sessions.
+
+Three things are present: what was wrong, what a person would have *seen*, and why the
+wrongness had consequences. All three are required.
+
+**Not this:**
+
+> ~~- Fixed a save bug~~
+> ~~- Updated the navmesh actor~~
+
+A reviewer cannot tell from that whether the change is correct, or whether it matters.
+
+Where a decision was deliberate and non-obvious — an ordering that must not be swapped, a
+tuning value chosen by feel — say so and say why. Those are the paragraphs a reviewer most
+needs and can least reconstruct.
+
+### `## Test plan`
+
+Actual commands and actual results. Never "tests pass."
+
+> - Editor target — clean build, 0 warnings
+> - `CompileAllBlueprints` — 412 assets, 0 failures
+> - `DieRobot.Settled.SaveLoad.*` — 6 tests, 0 failures
+> - **Smoke:** wave 1 from main menu, built 6 walls + 2 spike traps, saved, reloaded —
+>   base restored at 8 pieces, save file 41 KB. Sections 1–6 run; section 9 (leaderboard)
+>   not run, branch doesn't touch EOS.
+
+Name the new tests and what they cover. For any branch touching save/load, the build system,
+navigation, or waves, **the smoke result is not optional and "passed" is not a result** —
+state what you built, what came back, and what size.
+
+### `## Linked Issues`
+
+Every issue in full `DIE-XX` form, so Linear links each one.
+
+```markdown
+## Linked Issues
+DIE-XX, DIE-YY, DIE-ZZ
+```
+
+### Carry-up notes
+
+Anything left open goes at the end of `## Summary`: judgment calls not settled, work
+deliberately *not* done and why, decisions the reviewer should weigh in on.
+
+> **No automated test for the navmesh origin fix.** Verifying tile alignment requires a
+> loaded world and a built navmesh; the Settled suite currently has no world fixture.
+> Building one is a decision to make deliberately rather than inside a bug fix. Covered by
+> smoke section 4 instead.
+
+The purpose is to distinguish *deliberate omission* from *oversight*. A reviewer who cannot
+tell which they are looking at has to ask, and that round trip is what this prevents.
+
+### Enforcement
+
+Written standard plus a self-check before opening the PR. **No hook.** A hook can verify
+headings exist, and missing headings has never been the failure mode — thin prose under
+correct headings is, and that is not mechanically detectable.

--- a/.claude/rules/linear-issues.md
+++ b/.claude/rules/linear-issues.md
@@ -1,0 +1,214 @@
+# Linear Issue Rules — Die Robot
+
+How every Linear issue and project description is structured. The goal is a description a
+reader can **skim to the part they need** — not one they must read start to finish.
+
+Applies to `save_issue` and `save_project` alike, and to editing an existing description: if
+it lacks these sections, add them.
+
+Team **DIE**, initiative **Die Robot**.
+
+---
+
+## The Six Sections
+
+In this order. Every section is required except `## Technical Spec`.
+
+```markdown
+## Summary
+## Intent
+## Goals
+## Technical Spec      ← the only omittable section
+## Expected Result
+## Success Criteria
+```
+
+Each section has a **distinct job**. The failure mode this structure prevents is three
+sections all answering "what does done look like" in slightly different words — which makes
+an issue longer without making it clearer. If two sections would say the same thing, one of
+them is being written wrong.
+
+---
+
+### `## Summary`
+
+Two sentences. A ten-year-old understands it. **Zero technical terms** — no file names, class
+names, function names, acronyms, type names.
+
+> Right now the boss takes no damage at all — you can hit her forever and nothing happens.
+> This makes hitting the boss actually hurt her.
+
+**Not this:**
+
+> ~~`ADieRobotBoss::TakeDamage` hides `AActor::TakeDamage`, so the engine's damage dispatch
+> never reaches the override and the payload is discarded.~~
+
+That is true, and it belongs in the issue — under `Technical Spec`, not here.
+
+**The test:** read only this section, then explain the issue out loud to someone who has
+never seen the codebase. If you can't, it's still too technical. Rewrite it.
+
+---
+
+### `## Intent`
+
+The implied result, placed in Die Robot's context. One short paragraph. Answers *what larger
+thing is this part of* — the reason the work exists, not the work itself.
+
+> Boss fights are the payoff at the end of a wave block, and a boss that cannot be hurt turns
+> the game's biggest moment into a soft-lock. This is about the finale reading as a fight.
+
+**Not this:**
+
+> ~~Fix the TakeDamage override.~~
+
+That's a task, not an intent. Intent survives even if the implementation approach changes
+completely.
+
+**Where a design pillar or decision applies, name it.** `Serves P1.` or `Violates D4 —
+this issue removes the violation.` The vault's `Pillars & Decisions` is the reference, and an
+issue that connects to it is one someone can prioritise.
+
+---
+
+### `## Goals`
+
+Capabilities the game has afterward. Stated **without mechanism**.
+
+> - Every enemy, boss included, takes damage from every player damage source
+> - A new enemy type inherits working damage without extra wiring
+
+**Not this:**
+
+> ~~Add `override` to the TakeDamage declaration~~
+
+That is mechanism. Mechanism belongs in `Technical Spec` or `Expected Result`. A Goal should
+still read correctly if the implementation is rewritten from scratch.
+
+---
+
+### `## Technical Spec`
+
+Prior design carried in from earlier work — data layouts, constraints, decisions already
+settled elsewhere, links to a vault page. Anything the implementer would otherwise have to
+rediscover.
+
+**The only omittable section.** Many tasks carry no prior design. Omit the heading entirely
+rather than writing "N/A" — an empty required section is noise, and noise is what this format
+exists to remove.
+
+---
+
+### `## Expected Result`
+
+The concrete artifacts that will exist when the task is done. Classes, functions, assets,
+DataAssets, config entries, tests.
+
+> - `ADieRobotBoss::TakeDamage` declared `virtual ... override`
+> - `ABP_Boss_Lola` re-parented cleanly; its stale `BlackboardDataAsset` reference removed
+> - `DieRobot.Settled.Combat.BossTakesDamage` automation test
+
+**Not this:**
+
+> ~~- The boss will take damage~~
+
+That's a Goal in future tense. `Expected Result` answers *what will exist*, `Goals` answers
+*what will be possible*.
+
+---
+
+### `## Success Criteria`
+
+Binary, checkable gates. Checkbox list. Each item is something a reader can mark done or not
+done **without judgment**.
+
+> - [ ] Editor target compiles clean
+> - [ ] `CompileAllBlueprints` — 0 failures
+> - [ ] `DieRobot.Settled.Combat.*` green
+> - [ ] **Playable:** Lola's health bar drops on a melee hit and on a projectile hit
+> - [ ] **Playable:** wave 10 completes with the boss dying, from the main menu
+
+**Not this:**
+
+> ~~- [ ] Boss damage works correctly~~
+
+Nobody can mark that done. If a criterion needs an opinion to evaluate, rewrite it as
+something observable, or move it to `Goals`.
+
+#### Gameplay issues need a playable criterion
+
+This is the game-dev departure and it is not optional. **A compile-and-tests criterion set on
+a gameplay issue is incomplete**, because the entire recovery history of this project says so:
+three of the bugs found during the 5.8 upgrade were invisible to code review and only findable
+by running the game. DIE-24 survived eight sessions and would have fallen to one save/load
+round-trip.
+
+State what a person must **see** for the issue to be done — which map, which wave, which
+observable outcome. If you cannot write that sentence, the issue is not yet understood well
+enough to start.
+
+---
+
+## Formatting Rules
+
+**This has caused real damage before. Read before touching Linear.**
+
+**Never use `\n` escape sequences.** Linear does not render them — it stores the literal
+characters `\` and `n`, and every reader sees garbled text. The mistake happens when
+constructing a `description` parameter and reaching for `\n` as a newline escape.
+
+- Use actual line breaks (blank lines between paragraphs)
+- Markdown headings (`##`), bullets (`-`), bold (`**text**`) for structure
+- Code blocks use triple backticks with an actual newline after the opening fence
+- Never `\n`, `\\n`, or any escape sequence for a newline — ever
+
+**Pre-flight check** before calling `save_issue` or `save_project`: does the description
+string contain `\n`? If yes, rewrite with real line breaks before sending.
+
+---
+
+## Projects
+
+Every issue belongs to a project under the **Die Robot** initiative:
+
+| Project | Covers |
+|---|---|
+| Clean Up | Recovery, engine upgrade, setup, CI, test infrastructure |
+| Pathing Rework | DIE-27..38 — nav, corridor pathing, RVO, wall destruction |
+| GAS Migration | DIE-39..49 — ASC, attributes, effects, abilities |
+
+Bug issues found during other work still get filed to the project that owns the system, not
+to whatever project was in progress when they were noticed.
+
+## Labels
+
+The label set that actually exists on team DIE:
+
+- `Bug` — incorrect behavior, or a violation of a rule in `.claude/rules/`
+- `Improvement` — code improvement without new behavior (refactors, cleanup)
+- `Task` — maintenance, config, tooling, infrastructure
+- `Feature` — new player-facing capability
+- `Story` — a larger player-facing milestone spanning several issues
+
+**Not yet created, and worth adding when the work volume justifies it:** `Content` (Blueprint,
+asset, map, DataAsset work), `Design` (a question to answer rather than code to write), and
+`Perf` (frame time, allocation, load time). Until they exist, use `Task` and say which kind it
+is in the Summary — **do not label with something that isn't there**, and do not assume this
+list is current without checking `list_issue_labels`.
+
+## Status Flow
+
+**Backlog → In Progress → In Review → Done.** Link the issue to its project and set status in
+a single `save_issue` call at task start. Use state IDs, not names.
+
+`In Review` means the PR is open. An issue does not reach `Done` until the PR is merged — see
+`WORKFLOW.md` → C.6.
+
+## Design questions are issues too
+
+An open design question — the kind tracked in the vault's `Open Questions & Graveyard` — gets
+a Linear issue when an **experiment** is going to answer it, labelled `Design`.
+
+Its `Success Criteria` is not code. It is *the question is answered and the answer is written
+down in the vault.* An experiment with no recorded answer was not an experiment; it was a
+detour.

--- a/.claude/rules/unreal-style.md
+++ b/.claude/rules/unreal-style.md
@@ -1,0 +1,283 @@
+# Unreal C++ Style — Die Robot
+
+Conventions for C++ in this module. Where a rule below differs from what existing code does,
+the rule wins for **new** code — but do not sweep the codebase to conform. Opportunistic
+cleanup inside a file you're already editing is welcome; a rename-everything commit is not.
+
+---
+
+## File conventions
+
+- **Header comment:** `// Property of Paracosm.` as line 1 of every file.
+- **Indentation is tabs**, matching the existing tree and Epic's convention.
+- **Includes are module-relative from `Public/`**, never relative paths:
+
+  ```cpp
+  #include "Components/Combat/CombatComponent.h"   // yes
+  #include "../../Combat/CombatComponent.h"        // no
+  ```
+
+- Include order in a `.cpp`: own header first, blank line, then everything else.
+- `#pragma once` at the top of every header, then `CoreMinimal.h`, then the generated header
+  **last** — `.generated.h` must be the final include or UHT fails.
+
+## Naming
+
+Epic's prefixes are not optional — the reflection system depends on them.
+
+| Prefix | For |
+|---|---|
+| `A` | Actors — `ADieRobotPlayableCharacter` |
+| `U` | UObjects, components, subsystems — `UCombatComponent` |
+| `F` | Plain structs — `FAbilityContext`, `FBuildableData` |
+| `E` | Enums — `EOwnerWeaponState` |
+| `I` | Interfaces |
+| `b` | Booleans — `bCanEverTick`, `bIsPrimaryAbility` |
+
+- Types and functions: `PascalCase`. Locals and parameters: `PascalCase` too (Epic style,
+  not camelCase).
+- **New gameplay types take the `DieRobot` prefix**, not `Timber`. `Timber` is the pre-June
+  2026 module name. It survives in some Blueprint asset names (`GM_TimberGameModeBase`) —
+  harmless, rename opportunistically, never as a task.
+- Enum values get `UMETA(DisplayName = "...")` where the designer-facing name should differ.
+
+## UPROPERTY and UFUNCTION
+
+Every `UObject*` or `AActor*` member held by a UObject **must** be a `UPROPERTY`, even when
+it is not exposed:
+
+```cpp
+UPROPERTY()
+TObjectPtr<AActor> CachedTarget = nullptr;
+```
+
+Without it the garbage collector does not know about the reference, and the pointer dangles
+after a collection. This is the single most common source of "it crashed after twenty
+minutes" in Unreal.
+
+- **Prefer `TObjectPtr<T>` over raw `T*`** for new UPROPERTY members. Existing raw pointers
+  are fine where they are.
+- **Always initialize members at declaration** — `= nullptr`, `= 0.f`,
+  `= FVector::ZeroVector`. `FAbilityContext` does this correctly throughout; copy it.
+- Specifier intent:
+
+  | Specifier | Means |
+  |---|---|
+  | `EditDefaultsOnly` | Tuned on the Blueprint class. **The default for tuning values.** |
+  | `EditAnywhere` | Also tunable per placed instance. Use only when per-instance really varies. |
+  | `VisibleAnywhere` | Runtime state a designer should see but never set |
+  | `BlueprintReadOnly` | BP may read it. Prefer over `BlueprintReadWrite`. |
+  | `BlueprintReadWrite` | BP may write it — every write becomes un-reviewable. Justify it. |
+
+- Every `UPROPERTY` exposed to the editor gets a `Category`. Uncategorized properties land in
+  a heap at the bottom of the details panel.
+
+> **Changing any of these breaks Blueprints silently.** Renaming a `UPROPERTY`, changing its
+> type, or renaming a `UFUNCTION` invalidates every BP node referencing it, and C++ compiles
+> clean regardless. Run `CompileAllBlueprints` (WORKFLOW L.1, second gate) and add a
+> `CoreRedirect` when a rename is unavoidable.
+
+## Never mutate a UDataAsset at runtime
+
+A DataAsset is **shared state**. Every actor using it holds the same instance.
+
+```cpp
+// NO — this writes through into the shared asset
+FStatusEffect& Effect = EffectAsset->Effect;
+Effect.TimeRemaining = Effect.Duration;
+
+// Yes — copy, then mutate the copy
+FStatusEffect Effect = EffectAsset->Effect;
+Effect.TimeRemaining = Effect.Duration;
+```
+
+This is precisely DIE-13. `AddStatusEffectToComponent` takes a non-const reference into a
+`UDataAsset` and stores the effect *before* initialising `TimeRemaining`. The first
+application of each effect type per session silently fails; afterwards the asset is "primed"
+and it works. **Order-dependent, session-dependent, and near-impossible to reproduce in
+isolation** — which is why the rule is absolute rather than case-by-case.
+
+Take `const&` or by value from a DataAsset. If you need a mutable copy, say so by copying.
+
+## Null-check what you cast
+
+```cpp
+// The existing pattern in CombatComponent::BeginPlay — do not copy it
+OwningCharacter = Cast<ACharacter>(GetOwner());
+UE_LOG(LogTemp, Warning, TEXT("Owner: %s"), *OwningCharacter->GetName());  // ← crash
+
+// New code
+OwningCharacter = Cast<ACharacter>(GetOwner());
+if (!OwningCharacter)
+{
+    UE_LOG(LogDieRobot, Error, TEXT("%hs: owner is not a Character"), __FUNCTION__);
+    return;
+}
+```
+
+`Cast<>` returns null on failure — that is its contract. `CastChecked<>` is available when
+failure genuinely means a programming error and you want the assert.
+
+**Prefer an Interface to a concrete cast** when a component needs something from its owner.
+See `rules/architecture.md` → sideways dependencies for why: one `Cast<ADieRobotEnemyCharacter>`
+is what confines the entire status-effect system to enemies.
+
+## Logging
+
+Existing code uses `UE_LOG(LogTemp, Warning, ...)` almost everywhere. **`LogTemp` is not a
+log category, it is the absence of one** — it makes filtered log reading impossible and turns
+every shipping log into noise.
+
+New code declares and uses a project category:
+
+```cpp
+DECLARE_LOG_CATEGORY_EXTERN(LogDieRobot, Log, All);   // in a shared header
+DEFINE_LOG_CATEGORY(LogDieRobot);                     // in one .cpp
+```
+
+Levels mean things: `Error` for a broken invariant, `Warning` for a recoverable surprise,
+`Log` for lifecycle, `Verbose` for per-frame detail. **`Warning` for normal operation is
+noise**, and noise is why the real warning gets missed.
+
+Never log per-frame at `Log` or above. A string format on every tick is real cost.
+
+## Tick is opt-in and expensive
+
+```cpp
+PrimaryComponentTick.bCanEverTick = false;   // the default you should be writing
+```
+
+`UCombatComponent` currently sets `bCanEverTick = true` and its `TickComponent` does nothing
+but call `Super`. That is a per-frame virtual call and a tick-registration for no work, on
+every character in the level.
+
+Before enabling tick, ask whether the work is event-driven instead:
+
+- A timer (`GetWorldTimerManager().SetTimer`) for anything periodic but not per-frame
+- A delegate or the event subsystem for anything reactive
+- `SetComponentTickInterval()` when it must tick but not every frame
+
+If it must tick, keep the body allocation-free: no `TArray` construction, no string
+formatting, no `GetAllActorsOfClass`, no `FindComponentByClass`. Cache in `BeginPlay`.
+
+## Const-correctness
+
+- Getters are `const`. `GetAbilityInputRequirement(bool) const` is the existing good example.
+- Loop over containers by `const&`: `for (const FBuildableData& Data : Buildables)`. Copying
+  `FBuildableData` in a loop is not free — it carries ten directional GUIDs.
+- Take `const FString&` / `const TArray<T>&` parameters, not by value.
+
+## Containers and allocation
+
+- `Reserve()` before a loop whose size you know.
+- `TArray::Add` in a loop over thousands of items reallocates repeatedly — that plus
+  `SpawnActor`'s overlap sweep is DIE-26's O(n²).
+- Prefer `TMap` lookup to a linear `TArray` search on any path that runs more than once a
+  frame.
+- `MoveTemp()` when handing off ownership of a container rather than copying it.
+
+## Actors, spawning and destruction
+
+- Guard `Destroy()` paths against re-entrancy. DIE-16 is a missing death guard: without it a
+  single enemy can drop loot twice and drift the wave counter, because death can be signalled
+  from more than one path in the same frame.
+- Never dereference an `AActor*` cached last frame without `IsValid()`.
+- `SpawnActor` runs an overlap sweep against existing actors. In a loop, that is quadratic —
+  use `FActorSpawnParameters` with `ESpawnActorCollisionHandlingMethod::AlwaysSpawn` when the
+  placement is already known-good.
+
+## Overriding engine functions
+
+```cpp
+// NO — this hides AActor::TakeDamage rather than overriding it
+float TakeDamage(float Damage, ...);
+
+// Yes
+virtual float TakeDamage(float Damage, FDamageEvent const& DamageEvent,
+                         AController* EventInstigator, AActor* DamageCauser) override;
+```
+
+DIE-18 is exactly this hiding, and DIE-12 is its consequence: Boss Lola takes zero damage
+because the payload goes to a function that is never the one the engine calls. **Always write
+`override`.** The compiler then tells you when the signature is wrong, which is the entire
+point.
+
+## Member initializers are not computed at runtime
+
+```cpp
+// NO — computed once at construction, then serialized separately.
+// Editing BaseWeaponDamage on the Blueprint never updates this.
+float TotalWeaponDamage = BaseWeaponDamage * DamageModifierValue;
+
+// Yes — a function, computed when asked
+float GetTotalDamage() const { return BaseWeaponDamage * DamageModifierValue; }
+```
+
+DIE-15. The two melee paths currently disagree about which value to read, which is what a
+silently-stale derived member always eventually causes. **Derived values are functions, not
+fields.**
+
+## Comments
+
+**`/** */` on declarations, `//` on implementations.** Header comments are the contract;
+`.cpp` comments are the reasoning. A `.cpp` comment restating what the code does is
+deletable — a header comment explaining internal mechanics belongs in the `.cpp`. Most
+overgrown comments are one of those two sitting in the wrong file.
+
+### Header comments on reflected members are shipped UI
+
+UHT extracts the comment above a `UPROPERTY` or `UFUNCTION` into the `ToolTip` metadata. It
+becomes **the text a designer reads** hovering that property in the Details panel, and
+`@param` lines become the pin tooltips on the Blueprint node.
+
+So a comment on a reflected member has an audience who will never open the header. Write it
+for them. This is also the discipline that keeps comments short on its own — a six-line
+ramble is obviously wrong once you picture it in a tooltip box.
+
+### One line is the default
+
+The multi-line block is the exception and has to earn it — with `@param`, `@see`, or a
+genuine second idea.
+
+```cpp
+/** If true, the trap re-arms after its cooldown instead of being consumed. */
+UPROPERTY(EditDefaultsOnly, Category = "Trap")
+bool bRetriggerable = true;
+
+/**
+ * Applies an element at the given tier, combining with any tags already active.
+ * @param Element  Which of the five elements to apply.
+ * @param Tier     1-3, escalating. Tier 3 can trigger an emergent effect.
+ * @see USynergySystem::EvaluateCombination()
+ */
+```
+
+- **Booleans read `If true, …`** — the template forces the tight form. Epic uses it
+  throughout `Actor.h`.
+- **Prefer `@see` to prose.** Linking the related function beats re-explaining it, and the
+  link stays correct when the other side changes. This is the single biggest cure for
+  comments that sprawl.
+
+### `//~` for anything that must not become a tooltip
+
+The tilde suppresses doc extraction. `Actor.h` uses it 17 times:
+
+```cpp
+//~ Begin UActorComponent Interface
+virtual void BeginPlay() override;
+virtual void TickComponent(...) override;
+//~ End UActorComponent Interface
+```
+
+Without the tilde, an organizational comment sitting above a `UFUNCTION` becomes that
+function's tooltip — an interface marker shipped to a designer as documentation. Use `//~`
+for section dividers and interface blocks, always.
+
+### The rest
+
+- Comment **why**, not what. `// Using a Character because a character will always be the
+  owner of this component. Has Mesh.` is a good comment — it explains a choice.
+- A TODO names the problem and its cost, not just "fix this". The existing codebase does this
+  well; several TODOs correctly diagnose real design flaws before they bite.
+- When you accept a code-review finding rather than fixing it, the reasoning goes **in the
+  code**, at the site. An accepted finding with no written reason is a forgotten one.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,17 @@ DerivedDataCache/
 # Ignore Rider IDE files
 .idea/
 
+# Claude Code worktrees live inside .claude/ — the rest of .claude/ (WORKFLOW.md,
+# rules/, agents/) is deliberately tracked. Each worktree holds a .git file, so
+# without this git treats it as a nested repo and tries to record a gitlink.
+.claude/worktrees/
+
+# Per-user scratch content: EXP-lane assets, throwaway maps, tuning variants.
+# Ignored so it costs nothing in LFS, which is cumulative and permanent.
+# Committed test fixtures do NOT go here — functional test maps live in
+# Content/Maps/Tests/ so CI can run them.
+Content/Developers/
+
 # Ignore macOS specific files
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,279 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+Die Robot is a third-person wave-defense and base-building game in Unreal Engine 5.8.
+~29k lines of C++ across ~150 classes in a single module, plus a large Blueprint and
+content layer.
+
+---
+
+## Read this first
+
+Two documents outrank everything else at the start of a session:
+
+1. **`.claude/WORKFLOW.md`** — the order things happen. Setup, a change loop that repeats
+   once per logical change and ends in a reviewed commit, and a close-out run once per PR.
+2. **`~/Documents/RLOV/DieRobot/02 Technical/Current State.md`** — where the project
+   actually is right now: engine paths, toolchain traps, open bugs, and the gotchas that
+   have already cost hours.
+
+`.claude/rules/` holds the conventions. `WORKFLOW.md` holds the sequence. They are
+different files on purpose — do not look for conventions in the workflow.
+
+---
+
+## Git Commit Preferences
+
+Every commit follows this format exactly — subject line plus a structured body. The body is
+**required**, not optional.
+
+```
+DIE-XX: imperative subject line under 72 characters
+
+## What changed
+- Concrete bullet of each file/module-level change
+- Be specific: name the file and what was done to it
+
+## Why
+Clear explanation of the motivation. What problem does this solve?
+What was broken, missing, or wrong before? Why this approach over
+alternatives? Include context that won't be obvious from reading
+the diff alone.
+```
+
+**Full example:**
+
+```
+DIE-24: clear buildable and mission arrays before repopulating them
+
+## What changed
+- Source/DieRobot/Private/Subsystems/SaveLoad/SaveLoadSubsystem.cpp —
+  SaveBuildableData() now calls BuildingComponentsArray.Empty() before
+  the append loop
+- Source/DieRobot/Private/Subsystems/SaveLoad/SaveLoadSubsystem.cpp —
+  same treatment for PlayerData.CompletedMissionList
+
+## Why
+SaveCurrentGame() loads the existing save into SaveGameInstance before
+calling SaveBuildableData(), so the array arrived already populated and
+the append doubled it. InitializeSaveLoadSession() runs LoadGame() then
+SaveCurrentGame() on every level entry, so the doubling compounded once
+per visit: a 9-piece base reached 20,736 entries in eight loads, in a
+48 MB save file that froze the editor for minutes on load.
+
+Emptying is correct rather than de-duplicating because the in-memory
+array is the authority at save time — the file is a stale copy of it,
+not a second source of truth.
+```
+
+**Rules:**
+
+- Do NOT include "Co-Authored-By: Claude" or any similar attribution line
+- Issue ID is always the first token: `DIE-XX:`
+- Use an imperative verb: "add", "fix", "move", "remove", "refactor", "extract", "update"
+- Keep the subject line under 72 characters
+- One logical change per commit — don't bundle unrelated work
+- Both `## What changed` and `## Why` are required on every commit
+
+Full branching, push and PR rules live in `.claude/rules/git-workflow.md`.
+
+---
+
+## Build & Development Commands
+
+The engine is at **`D:\UnrealEngine\UE_5.8`** — a source/custom install, *not* the default
+Launcher path. Every command below needs the leading `&`: in PowerShell a quoted path at the
+start of a line is a string literal, not a command.
+
+```powershell
+# Compile the editor target
+& "D:\UnrealEngine\UE_5.8\Engine\Build\BatchFiles\Build.bat" DieRobotEditor Win64 Development -Project="C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -WaitMutex
+
+# Regenerate project files (after adding or moving source files)
+& "D:\UnrealEngine\UE_5.8\Engine\Build\BatchFiles\Build.bat" -projectfiles -project="C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -game -rocket -progress
+
+# Launch the editor directly, bypassing Rider
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject"
+
+# Compile every Blueprint headlessly — catches BP breakage a C++ change caused
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -run=CompileAllBlueprints -unattended -nopause
+```
+
+> **The editor must be closed before compiling.** UBT cannot replace a loaded DLL. A build
+> that appears to hang is usually waiting on `-WaitMutex` for an editor that is still open.
+
+> **The .NET 10 trap.** The engine ships its own .NET at
+> `Engine/Binaries/ThirdParty/DotNet/10.0/win-x64/` and `Build.bat` finds it via
+> `GetDotnetPath.bat`. **Rider and Visual Studio call the system `dotnet.exe` instead** and
+> fail with *"You must install or update .NET"* until a system-wide SDK 10 is installed.
+> Already resolved on this machine — but it is the first thing a fresh machine will hit.
+
+---
+
+## Architecture Overview
+
+One C++ module, `DieRobot`, using Unreal's standard `Public/` (headers) and `Private/`
+(implementation) split. Full detail and the layering rules are in
+`.claude/rules/architecture.md`.
+
+```
+DieRobot/
+├── Source/DieRobot/
+│   ├── Public/                   # Headers, mirrored folder-for-folder with Private/
+│   └── Private/
+│       ├── AI/                   # Controllers, behavior tree tasks & services
+│       ├── BuildSystem/          # Buildables: walls, ramps, traps, constructs
+│       ├── Character/            # Player and enemy characters
+│       ├── Components/           # Combat, build, inventory, mission, nav, status effect
+│       ├── Data/                 # DataAssets & DataTable row types
+│       ├── Subsystems/           # SaveLoad, Wave, Synergy, Events, Music, SFX, Online
+│       ├── Synergy/              # Element/tier effect handlers
+│       ├── UI/                   # Widgets (MVVM)
+│       └── ViewModels/           # MVVM view models
+├── Content/                      # Blueprints, assets, maps — LFS-tracked binary
+├── Config/                       # DefaultEngine.ini, DefaultGame.ini, Tags/
+└── docs/                         # ⚠ PUBLISHED GITHUB PAGES SITE — see below
+```
+
+### The systems that matter
+
+| System | Entry point | State |
+|---|---|---|
+| Build system | `Components/BuildSystem/BuildSystemManagerComponent.cpp` | Works, unarmored. Largest file in the project. |
+| Trap synergy | `Subsystems/SynergySystem/SynergySystem.cpp` | Five elements × three tiers + five emergent effects. One confirmed bug (DIE-13). |
+| Player abilities | `Components/Combat/CombatComponent.cpp` | A hand-rolled GAS. The GAS migration maps it nearly one-to-one. |
+| Missions | `Components/MissionDelivery/MissionDeliveryComponent.cpp` | The best-designed system here. Declarative GameplayTag subscriptions. |
+| AI & pathing | `AI/DieRobotAiControllerBase.cpp`, `Behavior/Tasks/Task_MoveThroughCorridorPathV2.cpp` | Recast corridor extraction. Owns its own Linear project. |
+| Waves | `Subsystems/Wave/WaveGameInstanceSubsystem.cpp` | Works. `ScaleHealth()` violates design decision D4. |
+| Save/load | `Subsystems/SaveLoad/SaveLoadSubsystem.cpp` | Works after DIE-24. Highest-blast-radius system in the game. |
+
+For honest per-system state — what is built, what is broken, and why — read
+`~/Documents/RLOV/DieRobot/02 Technical/Systems Inventory.md` rather than inferring from
+the code.
+
+---
+
+## Hard facts that bite
+
+**`docs/` is a published GitHub Pages site.** It has a `_config.yml` and serves
+`Portfolio/` and `RobinLifshitz/`. Anything placed there is **public**, not merely
+committed. Never put working documentation in it. Its only legitimate project content is
+`docs/smoke-checklist.md`, which is a test artifact.
+
+**`git status` clean does not mean backed up.** Use:
+
+```bash
+git log --branches --not --remotes --oneline
+```
+
+That is branch-agnostic and catches unpushed work anywhere. Eight months of work once sat
+unpushed because "clean" was read as "safe."
+
+**`Content/` is LFS-tracked and permanent.** ~14.8 GB stored against a 10 GB allowance.
+Every asset committed is stored forever — gitignoring something later caps growth but
+reclaims nothing. Think before adding bulk art.
+
+**Sentry is disabled and crash reporting is off.** The bundled plugin targeted engine 5.4
+and did not survive the 5.8 upgrade. `sentry.properties` remains but is inert. The disabled
+plugin entry in the uproject is a deliberate marker, not an oversight.
+
+**CoreRedirects in `Config/DefaultEngine.ini` are load-bearing for saves only.** After the
+full content resave, no asset references the old `timbermvp` module. Deleting the redirects
+now breaks any save written by an older build, and nothing else. Class redirects resolve
+**before** property and function redirects — any entry keyed on a `Timber*` class can never
+fire.
+
+---
+
+## Documentation
+
+The design vault lives in Obsidian at **`~/Documents/RLOV/DieRobot/`**. It is the source of
+truth for *why the game is the way it is* — pillars, decisions, open questions, system
+state, and the environment.
+
+Read the relevant page before proposing a plan that touches its area:
+
+| If you're touching... | Read in vault... |
+|---|---|
+| Anything, at session start | `02 Technical/Current State.md` |
+| A system's actual state or a known bug | `02 Technical/Systems Inventory.md` |
+| Enemy behavior, wave pacing, player verbs | `01 Design/Pillars & Decisions.md` |
+| A question the design hasn't settled | `01 Design/Open Questions & Graveyard.md` |
+| Why a technical choice was made | `03 Reference/Decision Log.md` |
+| A term you don't recognize | `03 Reference/Glossary.md` |
+| The setup and CI plan | `03 Reference/Setup Brief.md` |
+
+**The vault is not in git and is not committed to this repo.** That is deliberate — see the
+2026-08-14 Decision Log entry. This repo carries only agent configuration (`CLAUDE.md`,
+`.claude/`) and test artifacts.
+
+Vault drift is worse than no vault. When work changes something load-bearing, update the
+vault — see `.claude/WORKFLOW.md` → C.4.
+
+---
+
+## Issue Tracking
+
+Work is tracked in **Linear**, team **DIE**, under the **Die Robot** initiative:
+
+| Project | State |
+|---|---|
+| Clean Up | In progress — recovery, upgrade, setup |
+| Pathing Rework | Planned — DIE-27..38 |
+| GAS Migration | Planned — DIE-39..49 |
+
+When starting work:
+
+- Confirm an issue exists in the right project. Create one if not, per
+  `.claude/rules/linear-issues.md`.
+- Move it through **Backlog → In Progress → In Review → Done**.
+- Every commit references the issue ID (`DIE-XX: …`).
+
+**The one Linear rule worth restating here, because it causes real damage:** never use `\n`
+escape sequences in a Linear `description`. Linear does not render them — it stores the
+literal characters `\` and `n`, and the issue reads as garbage. Use actual line breaks.
+Pre-flight check before every `save_issue` / `save_project` call.
+
+---
+
+## Claude Setup
+
+- **`.claude/WORKFLOW.md`** — the per-task sequence. Follow it.
+- **`.claude/rules/`** — architecture, unreal-style, content-changes, git-workflow,
+  linear-issues.
+- **`.claude/agents/`** — `test-writer`, `performance-reviewer`, `linear-task-reviewer`.
+  Invoked by step in WORKFLOW.md.
+
+Code quality and style review is the **`code-review` skill**, invoked via the Skill tool
+before every commit — not an agent. `/code-review ultra` is a separate, user-triggered and
+billed slash command **Claude cannot launch**; it appears once, at close-out, behind the
+risk bar in WORKFLOW.md.
+
+There is no `security-auditor` here. Die Robot is a single-player offline game with no auth,
+no PII, and no server surface — a security audit of a trap damage calculation is theatre.
+The analogous blocking review is **`performance-reviewer`**, because in a game frame time is
+a feature and a 3 ms regression on the enemy tick is a real defect.
+
+---
+
+## Key Principles
+
+- **Frame time is a feature.** A change that is correct and costs 4 ms on the enemy tick is
+  not done. Cost is part of the diff.
+- **Data over code.** Traps, waves, effects, missions, loot and dialogue are already
+  DataAssets and DataTables. A new enemy, trap or effect should not require a C++ edit. When
+  it does, that is the finding.
+- **GameplayTags are the vocabulary.** They are pervasive already, which is why the GAS
+  migration is well-positioned. Prefer a tag to an `IsA` ladder — the `IsA` ladder in
+  `PopulateCombatEventContextTags` is the standing example of what not to do.
+- **Blueprint is a leaf, not a layer.** Logic that other systems depend on belongs in C++
+  where it can be reviewed, tested, and diffed. Blueprints hold composition, tuning values,
+  and presentation.
+- **Never mutate a `UDataAsset` at runtime.** Taking a non-const reference into a shared
+  asset and writing through it is exactly the bug in DIE-13: the first application per
+  session silently fails, the asset is then "primed", and it becomes unreproducible.
+- **The save file is the least forgiving surface in the project.** It is versioned by
+  nothing, read by every level load, and a bad write is discovered by a player, weeks later,
+  as a lost base. Treat every change to it as high risk.
+- **The vault holds the "why", the code holds the runtime "how".** Don't let them drift.


### PR DESCRIPTION
## Summary

**DIE-50 — the project carried no repo-level knowledge, so every restart rediscovered the same facts the expensive way.** Eight months of pause cost real hours to things that were knowable in advance: that `docs/` is a published GitHub Pages site and not a place for working notes, that a clean `git status` is not proof of a backup, that two plausible theories about an editor hang were both wrong where a callstack answered it in one frame. None of it lived in the repo. This adds `CLAUDE.md`, `.claude/WORKFLOW.md`, five rules and three agents so a fresh session starts useful instead of starting over.

The structure mirrors Harbor's `.claude/`, with four departures that are deliberate rather than incidental:

**`performance-reviewer` replaces `security-auditor` at L.3.** Die Robot is single-player and offline — no auth, no PII, no server, no untrusted input. Auditing a trap damage calculation for injection is theatre; auditing it for per-hit allocation is not. The agent is scoped to per-frame and per-enemy paths and is told never to invent millisecond figures it cannot measure from a diff.

**A content lane.** Everything under `Content/` is binary — `git diff` shows nothing, and the `code-review` skill cannot read a `.uasset`. So a written per-asset description plus a screenshot is not ceremony; it is the only artifact a reviewer will ever have. `rules/content-changes.md` also covers the LFS consequence: storage is cumulative and permanent, so gitignoring an asset later caps growth without reclaiming anything.

**An EXP lane, exempt from tests and review but never from process.** `exp/*` branches never merge — they graduate onto a `die-XX` branch taking every step, or they are deleted. The exemption is what makes experiments fast, and merging exempt code is how a codebase acquires a region nobody will touch. Every EXP branch owes a written answer in the vault; an experiment with no recorded answer was a detour.

**Two-lane CI.** Game builds are slow, and a full cook per PR would make CI something to route around — which is worse than not having it. Lane 1 (compile, `CompileAllBlueprints`, the Settled suite) is the merge gate; Lane 2 (package, perf capture) runs weekly and opens issues rather than blocking.

Two things the rules do that are worth calling out, because they are what make them stick:

**Every anti-pattern names the issue it already caused.** Never mutate a `UDataAsset` is DIE-13, including why the failure is order-dependent and unreproducible. Always write `override` is DIE-18, with DIE-12 as its consequence. Derived values are functions not fields is DIE-15. A rule whose cost is already on the board gets followed; an abstract one gets rationalised around.

**Comment style is included because in Unreal it is not only style.** UHT extracts the comment above a `UPROPERTY`/`UFUNCTION` into `ToolTip` metadata, so it becomes the text a designer reads in the Details panel and on Blueprint pins. A header comment on a reflected member is shipped UI with an audience who will never open the header — which is also what keeps Epic's own comments to one line. `//~` is documented for the same reason: without it, an interface marker above a `UFUNCTION` ships to a designer as that function's documentation.

### Carry-up notes

**The Settled suite and Lane 1 CI are marked aspirational, not asserted.** Neither exists — there is no `.github/` in this repo, and `Private/Tests/TestObj.cpp` is a shipped interactable lever rather than a test. A workflow claiming a gate it does not have teaches sessions to ignore the ones it does. Both name the Setup Brief phase that lands them.

**Three Linear labels in `rules/linear-issues.md` do not exist yet.** `Content`, `Design` and `Perf` are listed as "add when volume justifies", with instructions to use `Task` and check `list_issue_labels` rather than assume. The file was corrected mid-branch after I wrote labels that were not in the workspace.

**Not done here, deliberately:** moving `TestObj.cpp` out of `Private/Tests/` to `Private/Debug/` — it is a shipped gameplay actor in a folder named Tests, and it should move before the first real test lands, but as its own commit. Also open: a `.clang-format` (the only mechanical enforcement of style would otherwise be `CompileAllBlueprints`), and gitignoring `Content/Developers/` to make it a genuinely free scratch area for the EXP lane.

**Idiomacy enforcement is honest about being review-based.** One mechanical gate exists — `CompileAllBlueprints`, which catches the C++→Blueprint breakage class. Everything else is a model reading markdown and applying judgment. That is weaker than Harbor's `clippy -D warnings`, and the rules say so rather than implying a rigour that is not there.

## Test plan

No code changed, so there is nothing to compile and no test suite to run. What was verified:

- `git add -An` — stages exactly 11 paths, **zero** content from `.claude/worktrees/`, confirming the new `.gitignore` line works. The worktree holds a nested `.git` file git would otherwise record as a gitlink.
- WORKFLOW step headings — `S.1–3`, `L.1–5`, `C.1–6`, sequential, no gaps or duplicates. Checked after renumbering to insert the task-review step.
- Cross-references — every `rules/*.md` path and agent name referenced from `CLAUDE.md`, `WORKFLOW.md` and the rules resolves to a file that exists.
- Epic conventions verified against the 5.8 install rather than written from memory: comment and `//~` style from `GameFramework/Actor.h` (17 tilde comments), `WITH_AUTOMATION_TESTS` at `Misc/AutomationTest.h:64`, and `Private/Tests/` placement confirmed across `Core`, `AIModule`, `Analytics` and `CoreOnline`.
- Solution-file behavior confirmed in `VCProjectFileGenerator.cs:497–506` — 5.8 writes both `.sln` and `.slnx` unconditionally, which is why four solution files appear. All four are already gitignored and none are tracked; no change needed.
- `git log --branches --not --remotes` — empty after push, confirming the branch actually landed rather than failing on an LFS timeout with plausible-looking output.

Documentation-only per WORKFLOW: exempt from L.2, L.3, L.4, C.1, C.2 and C.4. Stated in the commit body. Every file is markdown except `.gitignore`, whose only edit is one exclusion line.

## Linked Issues
DIE-50
