### PR TITLE
DIE-53: adopt Unreal MCP for editor-connected development

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -178,6 +178,32 @@ Invoke the **`test-writer`** agent on the code that just landed.
 > tests you just wrote pass. A change to a system with no tests is the opportunity to give
 > it some, not a reason to skip.
 
+### Running them — MCP first, headless as fallback
+
+With the editor open and the Unreal MCP server running (DIE-53), run tests **in the live
+editor** via the `AutomationTestToolset`:
+
+```
+DiscoverTests  →  ListTests(nameFilter: "DieRobot.Settled")  →  RunTests(testNames: [...])
+                  →  GetTestResults
+```
+
+Results come back per-test with `state`, `duration`, `errors` and `warnings`. This is the
+fast path: no editor shutdown, no cold start.
+
+Two things to know about that toolset: `DiscoverTests` must run once per session before
+anything else works, and `ListTests` requires `nameFilter` and `tagFilter` to be present
+even when empty — the schema marks them required despite describing them as optional.
+
+The headless command remains the fallback, and is what CI will use:
+
+```powershell
+& "D:\UnrealEngine\UE_5.8\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "C:\Users\Robin Lifshitz\Documents\Unreal Projects\DieRobot\DieRobot.uproject" -ExecCmds="Automation RunTests DieRobot.Settled" -unattended -nopause -nosplash -testexit="Automation Test Queue Empty"
+```
+
+**Report the real result either way.** Never claim a test passes without the output in
+front of you.
+
 **Exemption:** documentation-only changes and the EXP lane skip this step.
 
 **Content-lane note:** a Blueprint or DataAsset change is usually not unit-testable. Its

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "unreal-mcp": {
+      "type": "http",
+      "url": "http://127.0.0.1:8000/mcp"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,43 @@ fire.
 
 ---
 
+## Unreal MCP
+
+The editor hosts an MCP server (UE 5.8, Experimental). `.mcp.json` points Claude Code at
+`http://127.0.0.1:8000/mcp`, so **with the editor open you get live editor tools natively** —
+no headless round-trips.
+
+`bEnableToolSearch` is on, so `tools/list` returns only three meta-tools:
+`list_toolsets`, `describe_toolset`, `call_tool`. Everything else is discovered through
+them. A short tool list is the designed behavior, not a failure.
+
+What's worth knowing is registered:
+
+| Toolset | Use |
+|---|---|
+| `AutomationTestToolset` | Run the Settled suite in-editor — WORKFLOW L.2's fast path |
+| `editor_toolset…ObjectTools` | `list_properties` / `get_properties` / `set_properties` on live objects |
+| `editor_toolset…DataAssetTools`, `DataTableTools` | The DIE-13 surface |
+| `EditorToolset.EditorAppToolset` | `StartPIE`, `StopPIE`, `CaptureViewport`, `SearchCVars` |
+| `editor_toolset…SceneTools` | Place and remove actors in the loaded level |
+| `EditorToolset.LogsToolset` | Read the output log, set category verbosity |
+| `GASToolsets` | AttributeSet, AbilitySystemInspector, GameplayCue — for the GAS Migration |
+| `aimodule_toolset…BehaviorTreeTools` | Inspect BT assets — for the Pathing Rework |
+| `GameplayTagsToolset` | Read and manage the tag vocabulary |
+
+**Live introspection is the point.** It reads what is actually loaded, not what is on disk —
+which is the only way to verify order-dependent runtime state like DIE-13.
+
+> **Security.** There is **no authentication layer**. It binds to loopback and rejects
+> non-loopback `Origin` headers, and that is the entire protection. `bAutoStartServer=True`
+> lives in `Saved/Config/WindowsEditor/EditorPerProjectUserSettings.ini`, which is
+> gitignored — **deliberately not in committed project config**, because this repo is public
+> and an auto-starting unauthenticated control port must not be the default for a clone.
+> Both plugins are `TargetAllowList: ["Editor"]` and can never reach a shipping build.
+
+**Not available:** `LiveCodingToolset` ships on disk but is absent from `AllToolsets`'
+dependency list, so it never registers. The editor still has to be **closed to compile**.
+
 ## Documentation
 
 The design vault lives in Obsidian at **`~/Documents/RLOV/DieRobot/`**. It is the source of

--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -124,6 +124,7 @@ CustomStageCopyHandler=
 +PrimaryAssetTypesToScan=(PrimaryAssetType="Map",AssetBaseClass="/Script/Engine.World",bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game/Maps")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
 +PrimaryAssetTypesToScan=(PrimaryAssetType="PrimaryAssetLabel",AssetBaseClass="/Script/Engine.PrimaryAssetLabel",bHasBlueprintClasses=False,bIsEditorOnly=True,Directories=((Path="/Game")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
 +PrimaryAssetTypesToScan=(PrimaryAssetType="Data Asset",AssetBaseClass="/Game/Assets/Buildables/00_DataAssets/DA_BuildingComponentBase.DA_BuildingComponentBase_C",bHasBlueprintClasses=True,bIsEditorOnly=False,Directories=((Path="/Game/Assets/Buildables/00_DataAssets")),SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=Unknown))
++PrimaryAssetTypesToScan=(PrimaryAssetType="GameFeatureData",AssetBaseClass="/Script/GameFeatures.GameFeatureData",bHasBlueprintClasses=False,bIsEditorOnly=False,Directories=,SpecificAssets=,Rules=(Priority=-1,ChunkId=-1,bApplyRecursively=True,CookRule=AlwaysCook))
 bOnlyCookProductionAssets=False
 bShouldManagerDetermineTypeAndName=False
 bShouldGuessTypeAndNameInEditor=True
@@ -134,7 +135,6 @@ MetaDataTagsForAssetRegistry=()
 [GameplayTags]
 +GameplayTagTableList=Config/SynergySystemTags.ini
 ImportTagsFromConfig=True
-
 
 
 

--- a/DieRobot.uproject
+++ b/DieRobot.uproject
@@ -17,6 +17,20 @@
 	],
 	"Plugins": [
 		{
+			"Name": "ModelContextProtocol",
+			"Enabled": true,
+			"TargetAllowList": [
+				"Editor"
+			]
+		},
+		{
+			"Name": "AllToolsets",
+			"Enabled": true,
+			"TargetAllowList": [
+				"Editor"
+			]
+		},
+		{
 			"Name": "Sentry",
 			"Enabled": false
 		},


### PR DESCRIPTION
## Summary

**DIE-53 — the editor was a black box to tooling; now it isn't.** UE 5.8 ships an MCP server that runs inside the editor, and this enables it. Two capabilities were measured against this project rather than assumed, and both remove friction from work already queued.

**Running automation tests works, end to end.** `DiscoverTests` returned **8,766 tests**; `RunTests` came back with structured per-test `state`, `duration`, `errors` and `warnings`. That is exactly what WORKFLOW L.2 needs, and it deletes the close-the-editor-and-cold-start cycle from the test loop. L.2 now documents the MCP path first and keeps the headless command as the fallback and CI's method.

**Reading live runtime state works.** `list_properties` on a loaded `BP_BasicWall_BuildingComponent` returned this project's own schema — `buildingOrientation`, `buildingComponentType`, and the top/bottom/right quadrant components. That is introspection of what is *actually loaded*, not what is on disk, and it is the only practical way to verify order-dependent state like DIE-13, where the first application of an effect silently fails and the shared DataAsset is then primed.

**`bAutoStartServer` is deliberately not in committed config.** The server has **no authentication layer at all** — loopback binding and non-loopback `Origin` rejection are the entire protection. This repository is public, and an auto-starting unauthenticated control port must not be the default for anyone who clones it. It lives in `Saved/Config/`, which is gitignored, so it is on for this machine and travels nowhere. Both plugins carry `TargetAllowList: ["Editor"]` and can never reach a shipping build.

**Second commit records a side effect rather than hiding it.** Enabling `AllToolsets` pulled in `GameFeaturesToolset` → the GameFeatures plugin → a `GameFeatureData` primary asset type the editor wrote into `DefaultGame.ini` on its own. It is committed rather than reverted, because reverting only means the next launch rewrites it and the file shows dirty on every clean checkout — churn that trains you to ignore the file.

### Carry-up notes

**Driving editor state is only partially proven, and the PR does not claim otherwise.** `StartPIE` / `StopPIE` / `IsPIERunning`, `SceneTools` placement and `ObjectTools.set_properties` all exist, but there is **no arbitrary console-command tool** — only `SearchCVars`. So "jump to wave 7" means writing the wave subsystem's property directly. Plausible, untested, left as follow-up.

**Live Coding is not available.** `LiveCodingToolset` ships on disk but is absent from `AllToolsets`' dependency list, so it never registers. **The editor still has to be closed to compile**, and `CLAUDE.md` says so rather than leaving a reader to find out.

**`AllToolsets` is not inert.** It aggregates 21 toolsets and some drag in plugins that mutate project config — the `DefaultGame.ini` entry is the proof. The narrower alternative is enabling only what is wanted (AutomationTest, Editor, GAS, AIModule, GameplayTags). That is the move if this file accumulates more entries nobody asked for; it is recorded in the commit body so the next person has the context rather than the mystery.

**Experimental.** Epic marks the plugin Experimental and cautions against shipping with it. The editor-only allowlist is the guard.

## Test plan

No project code changed — no compile, and the Settled suite still does not exist. What was actually exercised, against a live editor on the StartUp level:

- `initialize` → 200, session established, protocol `2025-06-18`, tools capability advertised
- `tools/list` → the three meta-tools (`list_toolsets`, `describe_toolset`, `call_tool`), matching the `bEnableToolSearch=true` default
- `list_toolsets` → 40+ toolsets registered, including `AutomationTestToolset`, `GASToolsets`, `BehaviorTreeTools`, `DataAssetTools`, `DataTableTools`
- `DiscoverTests` → `{"status": "ready"}`; `ListTests` → **8,766 total**, **0 matching "DieRobot"** (correct — the project has none)
- `RunTests` on two engine tests → **2 passed, 0 failed**, 0.034s total, with per-test durations and empty error arrays
- `list_properties` on `BP_BasicWall_BuildingComponent_C_98` → returned the real build-system schema
- `IsPIERunning` → `false`; `GetVisibleActors` → the loaded StartUp level's actor set
- Editor launched with both plugins and **no rebuild prompt**, as predicted from the prebuilt engine DLLs

Not verified: wave-state manipulation, and native MCP tools in a Claude Code session (requires a session restart to pick up `.mcp.json`).

## Ultra review required

`DieRobot.uproject` is on the **ultra risk bar** — build configuration. The trigger fired, and Claude cannot run `/code-review ultra`. Handing off.

## Linked Issues
DIE-53, DIE-52
